### PR TITLE
Include custom IdentityResources in client scope picker

### DIFF
--- a/source/Spydersoft.Identity/Models/Admin/ClientViewModels/ClientScopesViewModel.cs
+++ b/source/Spydersoft.Identity/Models/Admin/ClientViewModels/ClientScopesViewModel.cs
@@ -26,13 +26,19 @@ namespace Spydersoft.Identity.Models.Admin.ClientViewModels
         {
             ClientScopeViewModel child = base.GetChild(parent, configDbContext);
             child.Scopes = [.. configDbContext.ApiScopes.Select(scope => scope.Name)];
+            child.Scopes.AddRange(configDbContext.IdentityResources.Where(ir => ir.Enabled).Select(ir => ir.Name));
 
+            // Standard OIDC scopes are kept as a fallback in case the IdentityResources
+            // table hasn't been seeded yet (fresh install). Distinct below de-duplicates
+            // when they're also present in the database.
             child.Scopes.Add(IdentityServerConstants.StandardScopes.Address);
             child.Scopes.Add(IdentityServerConstants.StandardScopes.Email);
             child.Scopes.Add(IdentityServerConstants.StandardScopes.OfflineAccess);
             child.Scopes.Add(IdentityServerConstants.StandardScopes.OpenId);
             child.Scopes.Add(IdentityServerConstants.StandardScopes.Phone);
             child.Scopes.Add(IdentityServerConstants.StandardScopes.Profile);
+
+            child.Scopes = [.. child.Scopes.Distinct()];
 
             Duende.IdentityServer.EntityFramework.Entities.Client client = configDbContext.Clients.Include(c => c.AllowedScopes).FirstOrDefault(c => c.Id == parent.Id);
             if (client != null)


### PR DESCRIPTION
The client admin UI built its "available scopes" list from API scopes plus a hardcoded set of standard OIDC scopes (openid, profile, email, etc.) and ignored the IdentityResources table entirely. Custom identity resources — e.g. a "roles" resource emitting the role claim — could never be added to a client's allowed scopes through the UI, even though they were valid scopes on the server side. Now pulls enabled IdentityResources alongside ApiScopes, keeps the standard scopes as a fallback for unseeded installs, and de-dupes.