### PR TITLE
Fix admin UI: adding a sub-resource reloaded the page

### DIFF
--- a/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/api-resources/ApiResourceEdit.tsx
+++ b/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/api-resources/ApiResourceEdit.tsx
@@ -73,8 +73,7 @@ export default function ApiResourceEdit() {
   const update = <K extends keyof SaveApiResourceDto>(key: K, value: SaveApiResourceDto[K]) =>
     setDraft((d) => ({ ...d, [key]: value }));
 
-  const submit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const submit = async () => {
     setSaving(true);
     try {
       if (isNew) {
@@ -113,8 +112,7 @@ export default function ApiResourceEdit() {
         }
       />
 
-      <form onSubmit={submit}>
-        <TabView scrollable activeIndex={activeTab} onTabChange={(e) => setActiveTab(e.index)}>
+      <TabView scrollable activeIndex={activeTab} onTabChange={(e) => setActiveTab(e.index)}>
           <TabPanel header="Settings">
             <div className="space-y-8">
               <Section
@@ -176,14 +174,14 @@ export default function ApiResourceEdit() {
               <Button type="button" outlined label="Cancel" />
             </Link>
             <Button
-              type="submit"
+              type="button"
+              onClick={submit}
               loading={saving}
               label={isNew ? "Create API resource" : "Save changes"}
               icon={<FontAwesomeIcon icon={faSave} />}
             />
           </div>
         </div>
-      </form>
     </div>
   );
 }

--- a/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/api-resources/ApiResourceSubResources.tsx
+++ b/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/api-resources/ApiResourceSubResources.tsx
@@ -63,30 +63,31 @@ function SingleValuePanel<T extends { id?: number | string }>({
       describe={describe}
       columns={columns}
       emptyCreateDraft={{ value: "" }}
-      renderCreateForm={({ onCreated, createDraft, setCreateDraft }) => (
-        <form
-          className="flex gap-2"
-          onSubmit={async (e) => {
-            e.preventDefault();
-            if (!createDraft.value.trim()) return;
-            await create(createDraft.value.trim());
-            onCreated();
-          }}
-        >
-          <InputText
-            className="flex-1"
-            value={createDraft.value}
-            placeholder={placeholder}
-            onChange={(e) => setCreateDraft({ value: e.target.value })}
-          />
-          <Button
-            type="submit"
-            label="Add"
-            icon={<FontAwesomeIcon icon={faPlus} />}
-            disabled={!createDraft.value.trim()}
-          />
-        </form>
-      )}
+      renderCreateForm={({ onCreated, createDraft, setCreateDraft }) => {
+        const submit = async () => {
+          if (!createDraft.value.trim()) return;
+          await create(createDraft.value.trim());
+          onCreated();
+        };
+        return (
+          <div className="flex gap-2">
+            <InputText
+              className="flex-1"
+              value={createDraft.value}
+              placeholder={placeholder}
+              onChange={(e) => setCreateDraft({ value: e.target.value })}
+              onKeyDown={(e) => e.key === "Enter" && submit()}
+            />
+            <Button
+              type="button"
+              onClick={submit}
+              label="Add"
+              icon={<FontAwesomeIcon icon={faPlus} />}
+              disabled={!createDraft.value.trim()}
+            />
+          </div>
+        );
+      }}
     />
   );
 }
@@ -161,39 +162,41 @@ export function PropertiesPanel({ apiResourceId }: PanelProps) {
         { field: "value", header: "Value" },
       ]}
       emptyCreateDraft={{ key: "", value: "" }}
-      renderCreateForm={({ onCreated, createDraft, setCreateDraft }) => (
-        <form
-          className="flex gap-2"
-          onSubmit={async (e) => {
-            e.preventDefault();
-            if (!createDraft.key.trim() || !createDraft.value.trim()) return;
-            await postApiV1ApiresourcesByApiResourceIdProperties({
-              path: { apiResourceId },
-              body: { key: createDraft.key.trim(), value: createDraft.value.trim() },
-            });
-            onCreated();
-          }}
-        >
-          <InputText
-            className="flex-1"
-            value={createDraft.key}
-            placeholder="key"
-            onChange={(e) => setCreateDraft({ ...createDraft, key: e.target.value })}
-          />
-          <InputText
-            className="flex-1"
-            value={createDraft.value}
-            placeholder="value"
-            onChange={(e) => setCreateDraft({ ...createDraft, value: e.target.value })}
-          />
-          <Button
-            type="submit"
-            label="Add"
-            icon={<FontAwesomeIcon icon={faPlus} />}
-            disabled={!createDraft.key.trim() || !createDraft.value.trim()}
-          />
-        </form>
-      )}
+      renderCreateForm={({ onCreated, createDraft, setCreateDraft }) => {
+        const submit = async () => {
+          if (!createDraft.key.trim() || !createDraft.value.trim()) return;
+          await postApiV1ApiresourcesByApiResourceIdProperties({
+            path: { apiResourceId },
+            body: { key: createDraft.key.trim(), value: createDraft.value.trim() },
+          });
+          onCreated();
+        };
+        return (
+          <div className="flex gap-2">
+            <InputText
+              className="flex-1"
+              value={createDraft.key}
+              placeholder="key"
+              onChange={(e) => setCreateDraft({ ...createDraft, key: e.target.value })}
+              onKeyDown={(e) => e.key === "Enter" && submit()}
+            />
+            <InputText
+              className="flex-1"
+              value={createDraft.value}
+              placeholder="value"
+              onChange={(e) => setCreateDraft({ ...createDraft, value: e.target.value })}
+              onKeyDown={(e) => e.key === "Enter" && submit()}
+            />
+            <Button
+              type="button"
+              onClick={submit}
+              label="Add"
+              icon={<FontAwesomeIcon icon={faPlus} />}
+              disabled={!createDraft.key.trim() || !createDraft.value.trim()}
+            />
+          </div>
+        );
+      }}
     />
   );
 }
@@ -220,46 +223,46 @@ export function SecretsPanel({ apiResourceId }: PanelProps) {
         { field: "expiration", header: "Expires" },
       ]}
       emptyCreateDraft={emptyDraft}
-      renderCreateForm={({ onCreated }) => (
-        <form
-          className="grid grid-cols-1 gap-3 md:grid-cols-2"
-          onSubmit={async (e) => {
-            e.preventDefault();
-            if (!draft.type.trim() || !draft.value.trim()) return;
-            await postApiV1ApiresourcesByApiResourceIdSecrets({
-              path: { apiResourceId },
-              body: draft,
-            });
-            setDraft(emptyDraft);
-            onCreated();
-          }}
-        >
-          <div>
-            <label className="mb-1 block text-xs text-content-muted">Type</label>
-            <InputText className="w-full" value={draft.type} onChange={(e) => setDraft({ ...draft, type: e.target.value })} />
+      renderCreateForm={({ onCreated }) => {
+        const submit = async () => {
+          if (!draft.type.trim() || !draft.value.trim()) return;
+          await postApiV1ApiresourcesByApiResourceIdSecrets({
+            path: { apiResourceId },
+            body: draft,
+          });
+          setDraft(emptyDraft);
+          onCreated();
+        };
+        return (
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <div>
+              <label className="mb-1 block text-xs text-content-muted">Type</label>
+              <InputText className="w-full" value={draft.type} onChange={(e) => setDraft({ ...draft, type: e.target.value })} />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs text-content-muted">Value (will be SHA-256 hashed)</label>
+              <InputText className="w-full" value={draft.value} onChange={(e) => setDraft({ ...draft, value: e.target.value })} />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs text-content-muted">Description (optional)</label>
+              <InputText className="w-full" value={draft.description ?? ""} onChange={(e) => setDraft({ ...draft, description: e.target.value })} />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs text-content-muted">Expires (ISO date, optional)</label>
+              <InputText className="w-full" value={draft.expiration ?? ""} onChange={(e) => setDraft({ ...draft, expiration: e.target.value })} placeholder="2027-01-01T00:00:00Z" />
+            </div>
+            <div className="md:col-span-2">
+              <Button
+                type="button"
+                onClick={submit}
+                label="Add secret"
+                icon={<FontAwesomeIcon icon={faPlus} />}
+                disabled={!draft.type.trim() || !draft.value.trim()}
+              />
+            </div>
           </div>
-          <div>
-            <label className="mb-1 block text-xs text-content-muted">Value (will be SHA-256 hashed)</label>
-            <InputText className="w-full" value={draft.value} onChange={(e) => setDraft({ ...draft, value: e.target.value })} />
-          </div>
-          <div>
-            <label className="mb-1 block text-xs text-content-muted">Description (optional)</label>
-            <InputText className="w-full" value={draft.description ?? ""} onChange={(e) => setDraft({ ...draft, description: e.target.value })} />
-          </div>
-          <div>
-            <label className="mb-1 block text-xs text-content-muted">Expires (ISO date, optional)</label>
-            <InputText className="w-full" value={draft.expiration ?? ""} onChange={(e) => setDraft({ ...draft, expiration: e.target.value })} placeholder="2027-01-01T00:00:00Z" />
-          </div>
-          <div className="md:col-span-2">
-            <Button
-              type="submit"
-              label="Add secret"
-              icon={<FontAwesomeIcon icon={faPlus} />}
-              disabled={!draft.type.trim() || !draft.value.trim()}
-            />
-          </div>
-        </form>
-      )}
+        );
+      }}
     />
   );
 }

--- a/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/clients/ClientEdit.tsx
+++ b/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/clients/ClientEdit.tsx
@@ -121,8 +121,7 @@ export default function ClientEdit() {
   const update = <K extends keyof SaveClientDto>(key: K, value: SaveClientDto[K]) =>
     setDraft((d) => ({ ...d, [key]: value }));
 
-  const submit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const submit = async () => {
     setSaving(true);
     try {
       if (isNew) {
@@ -161,10 +160,9 @@ export default function ClientEdit() {
         }
       />
 
-      <form onSubmit={submit}>
-        <TabView scrollable activeIndex={activeTab} onTabChange={(e) => setActiveTab(e.index)}>
-          <TabPanel header="Settings">
-            <div className="space-y-8">
+      <TabView scrollable activeIndex={activeTab} onTabChange={(e) => setActiveTab(e.index)}>
+        <TabPanel header="Settings">
+          <div className="space-y-8">
               <Section
                 title="Basic information"
                 description="Identity and display details for this client."
@@ -302,34 +300,34 @@ export default function ClientEdit() {
                   <SwitchRow label="Non-editable" checked={draft.nonEditable ?? false} onChange={(v) => update("nonEditable", v)} />
                 </SwitchList>
               </Section>
-            </div>
-          </TabPanel>
-
-          {!isNew && <TabPanel header="Scopes"><ScopesPanel clientId={numericId} /></TabPanel>}
-          {!isNew && <TabPanel header="Grant types"><GrantTypesPanel clientId={numericId} /></TabPanel>}
-          {!isNew && <TabPanel header="Redirect URIs"><RedirectUrisPanel clientId={numericId} /></TabPanel>}
-          {!isNew && <TabPanel header="Post-logout URIs"><PostLogoutRedirectUrisPanel clientId={numericId} /></TabPanel>}
-          {!isNew && <TabPanel header="CORS origins"><CorsOriginsPanel clientId={numericId} /></TabPanel>}
-          {!isNew && <TabPanel header="Claims"><ClaimsPanel clientId={numericId} /></TabPanel>}
-          {!isNew && <TabPanel header="Secrets"><SecretsPanel clientId={numericId} /></TabPanel>}
-          {!isNew && <TabPanel header="Properties"><PropertiesPanel clientId={numericId} /></TabPanel>}
-          {!isNew && <TabPanel header="IdP restrictions"><IdpRestrictionsPanel clientId={numericId} /></TabPanel>}
-        </TabView>
-
-        <div className="fixed inset-x-0 bottom-0 left-60 z-10 border-t border-border bg-surface/95 backdrop-blur">
-          <div className="mx-auto flex w-full max-w-6xl items-center justify-end gap-2 px-6 py-3 md:px-8">
-            <Link to="/clients">
-              <Button type="button" outlined label="Cancel" />
-            </Link>
-            <Button
-              type="submit"
-              loading={saving}
-              label={isNew ? "Create client" : "Save changes"}
-              icon={<FontAwesomeIcon icon={faSave} />}
-            />
           </div>
+        </TabPanel>
+
+        {!isNew && <TabPanel header="Scopes"><ScopesPanel clientId={numericId} /></TabPanel>}
+        {!isNew && <TabPanel header="Grant types"><GrantTypesPanel clientId={numericId} /></TabPanel>}
+        {!isNew && <TabPanel header="Redirect URIs"><RedirectUrisPanel clientId={numericId} /></TabPanel>}
+        {!isNew && <TabPanel header="Post-logout URIs"><PostLogoutRedirectUrisPanel clientId={numericId} /></TabPanel>}
+        {!isNew && <TabPanel header="CORS origins"><CorsOriginsPanel clientId={numericId} /></TabPanel>}
+        {!isNew && <TabPanel header="Claims"><ClaimsPanel clientId={numericId} /></TabPanel>}
+        {!isNew && <TabPanel header="Secrets"><SecretsPanel clientId={numericId} /></TabPanel>}
+        {!isNew && <TabPanel header="Properties"><PropertiesPanel clientId={numericId} /></TabPanel>}
+        {!isNew && <TabPanel header="IdP restrictions"><IdpRestrictionsPanel clientId={numericId} /></TabPanel>}
+      </TabView>
+
+      <div className="fixed inset-x-0 bottom-0 left-60 z-10 border-t border-border bg-surface/95 backdrop-blur">
+        <div className="mx-auto flex w-full max-w-6xl items-center justify-end gap-2 px-6 py-3 md:px-8">
+          <Link to="/clients">
+            <Button type="button" outlined label="Cancel" />
+          </Link>
+          <Button
+            type="button"
+            onClick={submit}
+            loading={saving}
+            label={isNew ? "Create client" : "Save changes"}
+            icon={<FontAwesomeIcon icon={faSave} />}
+          />
         </div>
-      </form>
+      </div>
     </div>
   );
 }

--- a/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/clients/ClientSubResources.tsx
+++ b/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/clients/ClientSubResources.tsx
@@ -86,31 +86,32 @@ function SingleValuePanel<T extends { id?: number | string }>({
       describe={describe}
       columns={columns}
       emptyCreateDraft={{ value: "" }}
-      renderCreateForm={({ onCreated, createDraft, setCreateDraft }) => (
-        <form
-          className="flex gap-2"
-          onSubmit={async (e) => {
-            e.preventDefault();
-            if (!createDraft.value.trim()) return;
-            await create(createDraft.value.trim());
-            onCreated();
-          }}
-        >
-          <InputText
-            type={fieldType}
-            className="flex-1"
-            value={createDraft.value}
-            placeholder={placeholder}
-            onChange={(e) => setCreateDraft({ value: e.target.value })}
-          />
-          <Button
-            type="submit"
-            label="Add"
-            icon={<FontAwesomeIcon icon={faPlus} />}
-            disabled={!createDraft.value.trim()}
-          />
-        </form>
-      )}
+      renderCreateForm={({ onCreated, createDraft, setCreateDraft }) => {
+        const submit = async () => {
+          if (!createDraft.value.trim()) return;
+          await create(createDraft.value.trim());
+          onCreated();
+        };
+        return (
+          <div className="flex gap-2">
+            <InputText
+              type={fieldType}
+              className="flex-1"
+              value={createDraft.value}
+              placeholder={placeholder}
+              onChange={(e) => setCreateDraft({ value: e.target.value })}
+              onKeyDown={(e) => e.key === "Enter" && submit()}
+            />
+            <Button
+              type="button"
+              onClick={submit}
+              label="Add"
+              icon={<FontAwesomeIcon icon={faPlus} />}
+              disabled={!createDraft.value.trim()}
+            />
+          </div>
+        );
+      }}
     />
   );
 }
@@ -157,36 +158,38 @@ function KeyValuePanel<T extends { id?: number | string }>({
       describe={describe}
       columns={columns}
       emptyCreateDraft={{ key: "", value: "" }}
-      renderCreateForm={({ onCreated, createDraft, setCreateDraft }) => (
-        <form
-          className="flex gap-2"
-          onSubmit={async (e) => {
-            e.preventDefault();
-            if (!createDraft.key.trim() || !createDraft.value.trim()) return;
-            await create(createDraft.key.trim(), createDraft.value.trim());
-            onCreated();
-          }}
-        >
-          <InputText
-            className="flex-1"
-            value={createDraft.key}
-            placeholder={keyPlaceholder}
-            onChange={(e) => setCreateDraft({ ...createDraft, key: e.target.value })}
-          />
-          <InputText
-            className="flex-1"
-            value={createDraft.value}
-            placeholder={valuePlaceholder}
-            onChange={(e) => setCreateDraft({ ...createDraft, value: e.target.value })}
-          />
-          <Button
-            type="submit"
-            label="Add"
-            icon={<FontAwesomeIcon icon={faPlus} />}
-            disabled={!createDraft.key.trim() || !createDraft.value.trim()}
-          />
-        </form>
-      )}
+      renderCreateForm={({ onCreated, createDraft, setCreateDraft }) => {
+        const submit = async () => {
+          if (!createDraft.key.trim() || !createDraft.value.trim()) return;
+          await create(createDraft.key.trim(), createDraft.value.trim());
+          onCreated();
+        };
+        return (
+          <div className="flex gap-2">
+            <InputText
+              className="flex-1"
+              value={createDraft.key}
+              placeholder={keyPlaceholder}
+              onChange={(e) => setCreateDraft({ ...createDraft, key: e.target.value })}
+              onKeyDown={(e) => e.key === "Enter" && submit()}
+            />
+            <InputText
+              className="flex-1"
+              value={createDraft.value}
+              placeholder={valuePlaceholder}
+              onChange={(e) => setCreateDraft({ ...createDraft, value: e.target.value })}
+              onKeyDown={(e) => e.key === "Enter" && submit()}
+            />
+            <Button
+              type="button"
+              onClick={submit}
+              label="Add"
+              icon={<FontAwesomeIcon icon={faPlus} />}
+              disabled={!createDraft.key.trim() || !createDraft.value.trim()}
+            />
+          </div>
+        );
+      }}
     />
   );
 }
@@ -408,43 +411,43 @@ export function SecretsPanel({ clientId }: PanelProps) {
         { field: "expiration", header: "Expires" },
       ]}
       emptyCreateDraft={emptyDraft}
-      renderCreateForm={({ onCreated }) => (
-        <form
-          className="grid grid-cols-1 gap-3 md:grid-cols-2"
-          onSubmit={async (e) => {
-            e.preventDefault();
-            if (!draft.type.trim() || !draft.value.trim()) return;
-            await postApiV1ClientsByClientIdSecrets({ path: { clientId }, body: draft });
-            setDraft(emptyDraft);
-            onCreated();
-          }}
-        >
-          <div>
-            <label className="mb-1 block text-xs text-content-muted">Type</label>
-            <InputText className="w-full" value={draft.type} onChange={(e) => setDraft({ ...draft, type: e.target.value })} />
+      renderCreateForm={({ onCreated }) => {
+        const submit = async () => {
+          if (!draft.type.trim() || !draft.value.trim()) return;
+          await postApiV1ClientsByClientIdSecrets({ path: { clientId }, body: draft });
+          setDraft(emptyDraft);
+          onCreated();
+        };
+        return (
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <div>
+              <label className="mb-1 block text-xs text-content-muted">Type</label>
+              <InputText className="w-full" value={draft.type} onChange={(e) => setDraft({ ...draft, type: e.target.value })} />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs text-content-muted">Value (will be SHA-256 hashed)</label>
+              <InputText className="w-full" value={draft.value} onChange={(e) => setDraft({ ...draft, value: e.target.value })} />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs text-content-muted">Description (optional)</label>
+              <InputText className="w-full" value={draft.description ?? ""} onChange={(e) => setDraft({ ...draft, description: e.target.value })} />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs text-content-muted">Expires (ISO date, optional)</label>
+              <InputText className="w-full" value={draft.expiration ?? ""} onChange={(e) => setDraft({ ...draft, expiration: e.target.value })} placeholder="2027-01-01T00:00:00Z" />
+            </div>
+            <div className="md:col-span-2">
+              <Button
+                type="button"
+                onClick={submit}
+                label="Add secret"
+                icon={<FontAwesomeIcon icon={faPlus} />}
+                disabled={!draft.type.trim() || !draft.value.trim()}
+              />
+            </div>
           </div>
-          <div>
-            <label className="mb-1 block text-xs text-content-muted">Value (will be SHA-256 hashed)</label>
-            <InputText className="w-full" value={draft.value} onChange={(e) => setDraft({ ...draft, value: e.target.value })} />
-          </div>
-          <div>
-            <label className="mb-1 block text-xs text-content-muted">Description (optional)</label>
-            <InputText className="w-full" value={draft.description ?? ""} onChange={(e) => setDraft({ ...draft, description: e.target.value })} />
-          </div>
-          <div>
-            <label className="mb-1 block text-xs text-content-muted">Expires (ISO date, optional)</label>
-            <InputText className="w-full" value={draft.expiration ?? ""} onChange={(e) => setDraft({ ...draft, expiration: e.target.value })} placeholder="2027-01-01T00:00:00Z" />
-          </div>
-          <div className="md:col-span-2">
-            <Button
-              type="submit"
-              label="Add secret"
-              icon={<FontAwesomeIcon icon={faPlus} />}
-              disabled={!draft.type.trim() || !draft.value.trim()}
-            />
-          </div>
-        </form>
-      )}
+        );
+      }}
     />
   );
 }

--- a/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/identity-resources/IdentityResourceEdit.tsx
+++ b/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/identity-resources/IdentityResourceEdit.tsx
@@ -79,8 +79,7 @@ export default function IdentityResourceEdit() {
     value: SaveIdentityResourceDto[K],
   ) => setDraft((d) => ({ ...d, [key]: value }));
 
-  const submit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const submit = async () => {
     setSaving(true);
     try {
       if (isNew) {
@@ -119,8 +118,7 @@ export default function IdentityResourceEdit() {
         }
       />
 
-      <form onSubmit={submit}>
-        <TabView scrollable activeIndex={activeTab} onTabChange={(e) => setActiveTab(e.index)}>
+      <TabView scrollable activeIndex={activeTab} onTabChange={(e) => setActiveTab(e.index)}>
           <TabPanel header="Settings">
             <div className="space-y-8">
               <Section
@@ -206,14 +204,14 @@ export default function IdentityResourceEdit() {
               <Button type="button" outlined label="Cancel" />
             </Link>
             <Button
-              type="submit"
+              type="button"
+              onClick={submit}
               loading={saving}
               label={isNew ? "Create identity resource" : "Save changes"}
               icon={<FontAwesomeIcon icon={faSave} />}
             />
           </div>
         </div>
-      </form>
     </div>
   );
 }

--- a/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/identity-resources/IdentityResourceSubResources.tsx
+++ b/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/identity-resources/IdentityResourceSubResources.tsx
@@ -44,33 +44,34 @@ export function ClaimsPanel({ identityResourceId }: PanelProps) {
       describe={(row) => row.type ?? ""}
       columns={columns}
       emptyCreateDraft={{ value: "" }}
-      renderCreateForm={({ onCreated, createDraft, setCreateDraft }) => (
-        <form
-          className="flex gap-2"
-          onSubmit={async (e) => {
-            e.preventDefault();
-            if (!createDraft.value.trim()) return;
-            await postApiV1IdentityresourcesByIdentityResourceIdClaims({
-              path: { identityResourceId },
-              body: { type: createDraft.value.trim() },
-            });
-            onCreated();
-          }}
-        >
-          <InputText
-            className="flex-1"
-            value={createDraft.value}
-            placeholder="email"
-            onChange={(e) => setCreateDraft({ value: e.target.value })}
-          />
-          <Button
-            type="submit"
-            label="Add"
-            icon={<FontAwesomeIcon icon={faPlus} />}
-            disabled={!createDraft.value.trim()}
-          />
-        </form>
-      )}
+      renderCreateForm={({ onCreated, createDraft, setCreateDraft }) => {
+        const submit = async () => {
+          if (!createDraft.value.trim()) return;
+          await postApiV1IdentityresourcesByIdentityResourceIdClaims({
+            path: { identityResourceId },
+            body: { type: createDraft.value.trim() },
+          });
+          onCreated();
+        };
+        return (
+          <div className="flex gap-2">
+            <InputText
+              className="flex-1"
+              value={createDraft.value}
+              placeholder="email"
+              onChange={(e) => setCreateDraft({ value: e.target.value })}
+              onKeyDown={(e) => e.key === "Enter" && submit()}
+            />
+            <Button
+              type="button"
+              onClick={submit}
+              label="Add"
+              icon={<FontAwesomeIcon icon={faPlus} />}
+              disabled={!createDraft.value.trim()}
+            />
+          </div>
+        );
+      }}
     />
   );
 }
@@ -97,39 +98,41 @@ export function PropertiesPanel({ identityResourceId }: PanelProps) {
         { field: "value", header: "Value" },
       ]}
       emptyCreateDraft={{ key: "", value: "" }}
-      renderCreateForm={({ onCreated, createDraft, setCreateDraft }) => (
-        <form
-          className="flex gap-2"
-          onSubmit={async (e) => {
-            e.preventDefault();
-            if (!createDraft.key.trim() || !createDraft.value.trim()) return;
-            await postApiV1IdentityresourcesByIdentityResourceIdProperties({
-              path: { identityResourceId },
-              body: { key: createDraft.key.trim(), value: createDraft.value.trim() },
-            });
-            onCreated();
-          }}
-        >
-          <InputText
-            className="flex-1"
-            value={createDraft.key}
-            placeholder="key"
-            onChange={(e) => setCreateDraft({ ...createDraft, key: e.target.value })}
-          />
-          <InputText
-            className="flex-1"
-            value={createDraft.value}
-            placeholder="value"
-            onChange={(e) => setCreateDraft({ ...createDraft, value: e.target.value })}
-          />
-          <Button
-            type="submit"
-            label="Add"
-            icon={<FontAwesomeIcon icon={faPlus} />}
-            disabled={!createDraft.key.trim() || !createDraft.value.trim()}
-          />
-        </form>
-      )}
+      renderCreateForm={({ onCreated, createDraft, setCreateDraft }) => {
+        const submit = async () => {
+          if (!createDraft.key.trim() || !createDraft.value.trim()) return;
+          await postApiV1IdentityresourcesByIdentityResourceIdProperties({
+            path: { identityResourceId },
+            body: { key: createDraft.key.trim(), value: createDraft.value.trim() },
+          });
+          onCreated();
+        };
+        return (
+          <div className="flex gap-2">
+            <InputText
+              className="flex-1"
+              value={createDraft.key}
+              placeholder="key"
+              onChange={(e) => setCreateDraft({ ...createDraft, key: e.target.value })}
+              onKeyDown={(e) => e.key === "Enter" && submit()}
+            />
+            <InputText
+              className="flex-1"
+              value={createDraft.value}
+              placeholder="value"
+              onChange={(e) => setCreateDraft({ ...createDraft, value: e.target.value })}
+              onKeyDown={(e) => e.key === "Enter" && submit()}
+            />
+            <Button
+              type="button"
+              onClick={submit}
+              label="Add"
+              icon={<FontAwesomeIcon icon={faPlus} />}
+              disabled={!createDraft.key.trim() || !createDraft.value.trim()}
+            />
+          </div>
+        );
+      }}
     />
   );
 }

--- a/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/roles/RoleEdit.tsx
+++ b/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/roles/RoleEdit.tsx
@@ -51,8 +51,7 @@ export default function RoleEdit() {
     void load();
   }, [load]);
 
-  const submit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const submit = async () => {
     setSaving(true);
     try {
       if (isNew) {
@@ -101,8 +100,7 @@ export default function RoleEdit() {
         }
       />
 
-      <form onSubmit={submit}>
-        <TabView scrollable activeIndex={activeTab} onTabChange={(e) => setActiveTab(e.index)}>
+      <TabView scrollable activeIndex={activeTab} onTabChange={(e) => setActiveTab(e.index)}>
           <TabPanel header="Settings">
             <section className="rounded-xl border border-border bg-surface p-5 shadow-sm md:p-6">
               <header className="mb-5">
@@ -139,14 +137,14 @@ export default function RoleEdit() {
               <Button type="button" outlined label="Cancel" />
             </Link>
             <Button
-              type="submit"
+              type="button"
+              onClick={submit}
               loading={saving}
               label={isNew ? "Create role" : "Save changes"}
               icon={<FontAwesomeIcon icon={faSave} />}
             />
           </div>
         </div>
-      </form>
     </div>
   );
 }

--- a/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/roles/RoleSubResources.tsx
+++ b/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/roles/RoleSubResources.tsx
@@ -58,8 +58,7 @@ export function ClaimsPanel({ roleId }: PanelProps) {
     });
   };
 
-  const handleAdd = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleAdd = async () => {
     if (!type.trim()) return;
     setAdding(true);
     try {
@@ -120,27 +119,30 @@ export function ClaimsPanel({ roleId }: PanelProps) {
         <h4 className="mb-3 text-xs font-semibold uppercase tracking-wider text-content-muted">
           Add claim
         </h4>
-        <form className="flex gap-2" onSubmit={handleAdd}>
+        <div className="flex gap-2">
           <InputText
             className="flex-1"
             value={type}
             placeholder="type"
             onChange={(e) => setType(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleAdd()}
           />
           <InputText
             className="flex-1"
             value={value}
             placeholder="value"
             onChange={(e) => setValue(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && handleAdd()}
           />
           <Button
-            type="submit"
+            type="button"
+            onClick={handleAdd}
             label="Add"
             icon={<FontAwesomeIcon icon={faPlus} />}
             disabled={!type.trim() || adding}
             loading={adding}
           />
-        </form>
+        </div>
       </div>
     </div>
   );

--- a/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/scopes/ScopeEdit.tsx
+++ b/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/scopes/ScopeEdit.tsx
@@ -72,8 +72,7 @@ export default function ScopeEdit() {
   const update = <K extends keyof SaveScopeDto>(key: K, value: SaveScopeDto[K]) =>
     setDraft((d) => ({ ...d, [key]: value }));
 
-  const submit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const submit = async () => {
     setSaving(true);
     try {
       if (isNew) {
@@ -112,8 +111,7 @@ export default function ScopeEdit() {
         }
       />
 
-      <form onSubmit={submit}>
-        <TabView scrollable activeIndex={activeTab} onTabChange={(e) => setActiveTab(e.index)}>
+      <TabView scrollable activeIndex={activeTab} onTabChange={(e) => setActiveTab(e.index)}>
           <TabPanel header="Settings">
             <div className="space-y-8">
               <Section
@@ -193,14 +191,14 @@ export default function ScopeEdit() {
               <Button type="button" outlined label="Cancel" />
             </Link>
             <Button
-              type="submit"
+              type="button"
+              onClick={submit}
               loading={saving}
               label={isNew ? "Create scope" : "Save changes"}
               icon={<FontAwesomeIcon icon={faSave} />}
             />
           </div>
         </div>
-      </form>
     </div>
   );
 }

--- a/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/scopes/ScopeSubResources.tsx
+++ b/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/scopes/ScopeSubResources.tsx
@@ -40,33 +40,34 @@ export function ClaimsPanel({ scopeId }: PanelProps) {
       describe={(row) => row.type ?? ""}
       columns={columns}
       emptyCreateDraft={{ value: "" }}
-      renderCreateForm={({ onCreated, createDraft, setCreateDraft }) => (
-        <form
-          className="flex gap-2"
-          onSubmit={async (e) => {
-            e.preventDefault();
-            if (!createDraft.value.trim()) return;
-            await postApiV1ScopesByScopeIdClaims({
-              path: { scopeId },
-              body: { type: createDraft.value.trim() },
-            });
-            onCreated();
-          }}
-        >
-          <InputText
-            className="flex-1"
-            value={createDraft.value}
-            placeholder="email"
-            onChange={(e) => setCreateDraft({ value: e.target.value })}
-          />
-          <Button
-            type="submit"
-            label="Add"
-            icon={<FontAwesomeIcon icon={faPlus} />}
-            disabled={!createDraft.value.trim()}
-          />
-        </form>
-      )}
+      renderCreateForm={({ onCreated, createDraft, setCreateDraft }) => {
+        const submit = async () => {
+          if (!createDraft.value.trim()) return;
+          await postApiV1ScopesByScopeIdClaims({
+            path: { scopeId },
+            body: { type: createDraft.value.trim() },
+          });
+          onCreated();
+        };
+        return (
+          <div className="flex gap-2">
+            <InputText
+              className="flex-1"
+              value={createDraft.value}
+              placeholder="email"
+              onChange={(e) => setCreateDraft({ value: e.target.value })}
+              onKeyDown={(e) => e.key === "Enter" && submit()}
+            />
+            <Button
+              type="button"
+              onClick={submit}
+              label="Add"
+              icon={<FontAwesomeIcon icon={faPlus} />}
+              disabled={!createDraft.value.trim()}
+            />
+          </div>
+        );
+      }}
     />
   );
 }
@@ -89,39 +90,41 @@ export function PropertiesPanel({ scopeId }: PanelProps) {
         { field: "value", header: "Value" },
       ]}
       emptyCreateDraft={{ key: "", value: "" }}
-      renderCreateForm={({ onCreated, createDraft, setCreateDraft }) => (
-        <form
-          className="flex gap-2"
-          onSubmit={async (e) => {
-            e.preventDefault();
-            if (!createDraft.key.trim() || !createDraft.value.trim()) return;
-            await postApiV1ScopesByScopeIdProperties({
-              path: { scopeId },
-              body: { key: createDraft.key.trim(), value: createDraft.value.trim() },
-            });
-            onCreated();
-          }}
-        >
-          <InputText
-            className="flex-1"
-            value={createDraft.key}
-            placeholder="key"
-            onChange={(e) => setCreateDraft({ ...createDraft, key: e.target.value })}
-          />
-          <InputText
-            className="flex-1"
-            value={createDraft.value}
-            placeholder="value"
-            onChange={(e) => setCreateDraft({ ...createDraft, value: e.target.value })}
-          />
-          <Button
-            type="submit"
-            label="Add"
-            icon={<FontAwesomeIcon icon={faPlus} />}
-            disabled={!createDraft.key.trim() || !createDraft.value.trim()}
-          />
-        </form>
-      )}
+      renderCreateForm={({ onCreated, createDraft, setCreateDraft }) => {
+        const submit = async () => {
+          if (!createDraft.key.trim() || !createDraft.value.trim()) return;
+          await postApiV1ScopesByScopeIdProperties({
+            path: { scopeId },
+            body: { key: createDraft.key.trim(), value: createDraft.value.trim() },
+          });
+          onCreated();
+        };
+        return (
+          <div className="flex gap-2">
+            <InputText
+              className="flex-1"
+              value={createDraft.key}
+              placeholder="key"
+              onChange={(e) => setCreateDraft({ ...createDraft, key: e.target.value })}
+              onKeyDown={(e) => e.key === "Enter" && submit()}
+            />
+            <InputText
+              className="flex-1"
+              value={createDraft.value}
+              placeholder="value"
+              onChange={(e) => setCreateDraft({ ...createDraft, value: e.target.value })}
+              onKeyDown={(e) => e.key === "Enter" && submit()}
+            />
+            <Button
+              type="button"
+              onClick={submit}
+              label="Add"
+              icon={<FontAwesomeIcon icon={faPlus} />}
+              disabled={!createDraft.key.trim() || !createDraft.value.trim()}
+            />
+          </div>
+        );
+      }}
     />
   );
 }

--- a/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/users/UserEdit.tsx
+++ b/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/users/UserEdit.tsx
@@ -80,8 +80,7 @@ export default function UserEdit() {
   const update = <K extends keyof Draft>(key: K, value: Draft[K]) =>
     setDraft((d) => ({ ...d, [key]: value }));
 
-  const submit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const submit = async () => {
     setSaving(true);
     try {
       if (isNew) {
@@ -147,8 +146,7 @@ export default function UserEdit() {
         }
       />
 
-      <form onSubmit={submit}>
-        <TabView scrollable activeIndex={activeTab} onTabChange={(e) => setActiveTab(e.index)}>
+      <TabView scrollable activeIndex={activeTab} onTabChange={(e) => setActiveTab(e.index)}>
           <TabPanel header="Settings">
             <div className="space-y-8">
               <Section
@@ -236,14 +234,14 @@ export default function UserEdit() {
               <Button type="button" outlined label="Cancel" />
             </Link>
             <Button
-              type="submit"
+              type="button"
+              onClick={submit}
               loading={saving}
               label={isNew ? "Create user" : "Save changes"}
               icon={<FontAwesomeIcon icon={faSave} />}
             />
           </div>
         </div>
-      </form>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Clicking **Add** on a client's Scopes tab (and other sub-resource panels like Grant types, Redirect URIs, Claims, Secrets, Properties) submitted a native `<form>` nested inside the outer client-edit `<form>`. Submit events bubble, so the inner submit also fired the outer form's handler; combined with invalid nested-form HTML, this caused a full page reload that dropped the user back on the Settings tab instead of adding the row.
- Removed `<form>`/`onSubmit`/`preventDefault` across all admin resource editors (Clients, API Resources, Identity Resources, Roles, Scopes, Users) and their sub-resource "Add" panels, since these are async API calls rather than real form posts — switched to plain `onClick` handlers. Enter-to-submit is preserved on the "Add" row inputs via an `onKeyDown` check for the Enter key.

## Test plan
- [ ] Open a client, go to the Scopes tab, add a scope — confirm it appends to the list without navigating away or resetting to the Settings tab
- [ ] Repeat for Grant types, Redirect URIs, Post-logout URIs, CORS origins, Claims, Secrets, Properties, IdP restrictions on Clients
- [ ] Repeat Add-row smoke test on API Resources, Identity Resources, Roles, Scopes sub-resource panels
- [ ] Confirm Save changes still works on each resource's Settings tab (Client, API Resource, Identity Resource, Role, Scope, User)
- [ ] Confirm Enter key still submits an "Add" row from within its text input