### PR TITLE
Admin API fixes to support a future Terraform provider

### DIFF
--- a/source/Spydersoft.Identity.Admin.Api/Controllers/V1/ApiResourceControllers.cs
+++ b/source/Spydersoft.Identity.Admin.Api/Controllers/V1/ApiResourceControllers.cs
@@ -42,6 +42,18 @@ namespace Spydersoft.Identity.Admin.Api.Controllers.V1
             return entity is null ? NotFound() : Ok(Mapper.Map<ApiResourceDto>(entity));
         }
 
+        /// <summary>Gets the API resource with the specified natural <c>Name</c> key.</summary>
+        /// <param name="name">The name of the API resource.</param>
+        /// <returns>A <see cref="StatusCodes.Status200OK"/> response containing the API resource, or <see cref="StatusCodes.Status404NotFound"/> if it does not exist.</returns>
+        [HttpGet("by-name/{name}")]
+        [ProducesResponseType<ApiResourceDto>(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public IActionResult GetByName(string name)
+        {
+            var entity = dbContext.ApiResources.FirstOrDefault(r => r.Name == name);
+            return entity is null ? NotFound() : Ok(Mapper.Map<ApiResourceDto>(entity));
+        }
+
         /// <summary>Creates a new API resource.</summary>
         /// <param name="dto">The API resource details to create.</param>
         /// <returns>A <see cref="StatusCodes.Status201Created"/> response containing the created API resource, or <see cref="StatusCodes.Status400BadRequest"/> if the request is invalid.</returns>
@@ -139,10 +151,13 @@ namespace Spydersoft.Identity.Admin.Api.Controllers.V1
         [Authorize(Policy = AdminApiPolicies.Write)]
         [ProducesResponseType<ApiResourceClaimDto>(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status409Conflict)]
         public async Task<IActionResult> Create(int apiResourceId, [FromBody] SaveApiResourceClaimDto dto)
         {
             var resource = await dbContext.ApiResources.Include(r => r.UserClaims).FirstOrDefaultAsync(r => r.Id == apiResourceId);
             if (resource is null) return NotFound();
+            if (resource.UserClaims.Any(x => x.Type == dto.Type))
+                return Conflict($"A claim with type '{dto.Type}' already exists for this API resource.");
             var entity = Mapper.Map<Duende.IdentityServer.EntityFramework.Entities.ApiResourceClaim>(dto);
             entity.ApiResourceId = apiResourceId;
             resource.UserClaims.Add(entity);
@@ -214,10 +229,13 @@ namespace Spydersoft.Identity.Admin.Api.Controllers.V1
         [Authorize(Policy = AdminApiPolicies.Write)]
         [ProducesResponseType<ApiResourcePropertyDto>(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status409Conflict)]
         public async Task<IActionResult> Create(int apiResourceId, [FromBody] SaveApiResourcePropertyDto dto)
         {
             var resource = await dbContext.ApiResources.Include(r => r.Properties).FirstOrDefaultAsync(r => r.Id == apiResourceId);
             if (resource is null) return NotFound();
+            if (resource.Properties.Any(x => x.Key == dto.Key))
+                return Conflict($"A property with key '{dto.Key}' already exists for this API resource.");
             var entity = Mapper.Map<Duende.IdentityServer.EntityFramework.Entities.ApiResourceProperty>(dto);
             entity.ApiResourceId = apiResourceId;
             resource.Properties.Add(entity);
@@ -289,10 +307,13 @@ namespace Spydersoft.Identity.Admin.Api.Controllers.V1
         [Authorize(Policy = AdminApiPolicies.Write)]
         [ProducesResponseType<ApiResourceScopeDto>(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status409Conflict)]
         public async Task<IActionResult> Create(int apiResourceId, [FromBody] SaveApiResourceScopeDto dto)
         {
             var resource = await dbContext.ApiResources.Include(r => r.Scopes).FirstOrDefaultAsync(r => r.Id == apiResourceId);
             if (resource is null) return NotFound();
+            if (resource.Scopes.Any(x => x.Scope == dto.Scope))
+                return Conflict($"A scope '{dto.Scope}' already exists for this API resource.");
             var entity = Mapper.Map<Duende.IdentityServer.EntityFramework.Entities.ApiResourceScope>(dto);
             entity.ApiResourceId = apiResourceId;
             resource.Scopes.Add(entity);

--- a/source/Spydersoft.Identity.Admin.Api/Controllers/V1/ClientSubResourceControllers.cs
+++ b/source/Spydersoft.Identity.Admin.Api/Controllers/V1/ClientSubResourceControllers.cs
@@ -62,10 +62,13 @@ namespace Spydersoft.Identity.Admin.Api.Controllers.V1
         [Authorize(Policy = AdminApiPolicies.Write)]
         [ProducesResponseType<ClientClaimDto>(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status409Conflict)]
         public async Task<IActionResult> Create(int clientId, [FromBody] SaveClientClaimDto dto)
         {
             var client = await dbContext.Clients.Include(c => c.Claims).FirstOrDefaultAsync(c => c.Id == clientId);
             if (client is null) return NotFound();
+            if (client.Claims.Any(x => x.Type == dto.Type && x.Value == dto.Value))
+                return Conflict($"A claim with type '{dto.Type}' and value '{dto.Value}' already exists for this client.");
             var entity = Mapper.Map<ClientClaim>(dto);
             entity.ClientId = clientId;
             client.Claims.Add(entity);
@@ -137,10 +140,13 @@ namespace Spydersoft.Identity.Admin.Api.Controllers.V1
         [Authorize(Policy = AdminApiPolicies.Write)]
         [ProducesResponseType<ClientCorsOriginDto>(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status409Conflict)]
         public async Task<IActionResult> Create(int clientId, [FromBody] SaveClientCorsOriginDto dto)
         {
             var client = await dbContext.Clients.Include(c => c.AllowedCorsOrigins).FirstOrDefaultAsync(c => c.Id == clientId);
             if (client is null) return NotFound();
+            if (client.AllowedCorsOrigins.Any(x => x.Origin == dto.Origin))
+                return Conflict($"A CORS origin '{dto.Origin}' already exists for this client.");
             var entity = Mapper.Map<ClientCorsOrigin>(dto);
             entity.ClientId = clientId;
             client.AllowedCorsOrigins.Add(entity);
@@ -212,10 +218,13 @@ namespace Spydersoft.Identity.Admin.Api.Controllers.V1
         [Authorize(Policy = AdminApiPolicies.Write)]
         [ProducesResponseType<ClientGrantTypeDto>(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status409Conflict)]
         public async Task<IActionResult> Create(int clientId, [FromBody] SaveClientGrantTypeDto dto)
         {
             var client = await dbContext.Clients.Include(c => c.AllowedGrantTypes).FirstOrDefaultAsync(c => c.Id == clientId);
             if (client is null) return NotFound();
+            if (client.AllowedGrantTypes.Any(x => x.GrantType == dto.GrantType))
+                return Conflict($"A grant type '{dto.GrantType}' already exists for this client.");
             var entity = Mapper.Map<ClientGrantType>(dto);
             entity.ClientId = clientId;
             client.AllowedGrantTypes.Add(entity);
@@ -287,10 +296,13 @@ namespace Spydersoft.Identity.Admin.Api.Controllers.V1
         [Authorize(Policy = AdminApiPolicies.Write)]
         [ProducesResponseType<ClientIdpRestrictionDto>(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status409Conflict)]
         public async Task<IActionResult> Create(int clientId, [FromBody] SaveClientIdpRestrictionDto dto)
         {
             var client = await dbContext.Clients.Include(c => c.IdentityProviderRestrictions).FirstOrDefaultAsync(c => c.Id == clientId);
             if (client is null) return NotFound();
+            if (client.IdentityProviderRestrictions.Any(x => x.Provider == dto.Provider))
+                return Conflict($"An identity provider restriction '{dto.Provider}' already exists for this client.");
             var entity = Mapper.Map<ClientIdPRestriction>(dto);
             entity.ClientId = clientId;
             client.IdentityProviderRestrictions.Add(entity);
@@ -362,10 +374,13 @@ namespace Spydersoft.Identity.Admin.Api.Controllers.V1
         [Authorize(Policy = AdminApiPolicies.Write)]
         [ProducesResponseType<ClientPostLogoutRedirectUriDto>(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status409Conflict)]
         public async Task<IActionResult> Create(int clientId, [FromBody] SaveClientPostLogoutRedirectUriDto dto)
         {
             var client = await dbContext.Clients.Include(c => c.PostLogoutRedirectUris).FirstOrDefaultAsync(c => c.Id == clientId);
             if (client is null) return NotFound();
+            if (client.PostLogoutRedirectUris.Any(x => x.PostLogoutRedirectUri == dto.PostLogoutRedirectUri))
+                return Conflict($"A post-logout redirect URI '{dto.PostLogoutRedirectUri}' already exists for this client.");
             var entity = Mapper.Map<ClientPostLogoutRedirectUri>(dto);
             entity.ClientId = clientId;
             client.PostLogoutRedirectUris.Add(entity);
@@ -437,10 +452,13 @@ namespace Spydersoft.Identity.Admin.Api.Controllers.V1
         [Authorize(Policy = AdminApiPolicies.Write)]
         [ProducesResponseType<ClientPropertyDto>(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status409Conflict)]
         public async Task<IActionResult> Create(int clientId, [FromBody] SaveClientPropertyDto dto)
         {
             var client = await dbContext.Clients.Include(c => c.Properties).FirstOrDefaultAsync(c => c.Id == clientId);
             if (client is null) return NotFound();
+            if (client.Properties.Any(x => x.Key == dto.Key))
+                return Conflict($"A property with key '{dto.Key}' already exists for this client.");
             var entity = Mapper.Map<ClientProperty>(dto);
             entity.ClientId = clientId;
             client.Properties.Add(entity);
@@ -512,10 +530,13 @@ namespace Spydersoft.Identity.Admin.Api.Controllers.V1
         [Authorize(Policy = AdminApiPolicies.Write)]
         [ProducesResponseType<ClientRedirectUriDto>(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status409Conflict)]
         public async Task<IActionResult> Create(int clientId, [FromBody] SaveClientRedirectUriDto dto)
         {
             var client = await dbContext.Clients.Include(c => c.RedirectUris).FirstOrDefaultAsync(c => c.Id == clientId);
             if (client is null) return NotFound();
+            if (client.RedirectUris.Any(x => x.RedirectUri == dto.RedirectUri))
+                return Conflict($"A redirect URI '{dto.RedirectUri}' already exists for this client.");
             var entity = Mapper.Map<ClientRedirectUri>(dto);
             entity.ClientId = clientId;
             client.RedirectUris.Add(entity);
@@ -587,10 +608,13 @@ namespace Spydersoft.Identity.Admin.Api.Controllers.V1
         [Authorize(Policy = AdminApiPolicies.Write)]
         [ProducesResponseType<ClientScopeDto>(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status409Conflict)]
         public async Task<IActionResult> Create(int clientId, [FromBody] SaveClientScopeDto dto)
         {
             var client = await dbContext.Clients.Include(c => c.AllowedScopes).FirstOrDefaultAsync(c => c.Id == clientId);
             if (client is null) return NotFound();
+            if (client.AllowedScopes.Any(x => x.Scope == dto.Scope))
+                return Conflict($"A scope '{dto.Scope}' already exists for this client.");
             var entity = Mapper.Map<ClientScope>(dto);
             entity.ClientId = clientId;
             client.AllowedScopes.Add(entity);

--- a/source/Spydersoft.Identity.Admin.Api/Controllers/V1/ClientsController.cs
+++ b/source/Spydersoft.Identity.Admin.Api/Controllers/V1/ClientsController.cs
@@ -45,6 +45,19 @@ namespace Spydersoft.Identity.Admin.Api.Controllers.V1
             return Ok(Mapper.Map<ClientDto>(client));
         }
 
+        /// <summary>Returns the full detail of a single client, looked up by its natural <c>ClientId</c> key.</summary>
+        [HttpGet("by-client-id/{clientId}")]
+        [ProducesResponseType<ClientDto>(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public IActionResult GetByClientId(string clientId)
+        {
+            var client = dbContext.Clients.FirstOrDefault(c => c.ClientId == clientId);
+            if (client is null)
+                return NotFound();
+
+            return Ok(Mapper.Map<ClientDto>(client));
+        }
+
         /// <summary>Creates a new client.</summary>
         [HttpPost]
         [Authorize(Policy = AdminApiPolicies.Write)]

--- a/source/Spydersoft.Identity.Admin.Api/Controllers/V1/IdentityResourceControllers.cs
+++ b/source/Spydersoft.Identity.Admin.Api/Controllers/V1/IdentityResourceControllers.cs
@@ -42,6 +42,18 @@ namespace Spydersoft.Identity.Admin.Api.Controllers.V1
             return entity is null ? NotFound() : Ok(Mapper.Map<IdentityResourceDto>(entity));
         }
 
+        /// <summary>Gets the identity resource with the specified natural <c>Name</c> key.</summary>
+        /// <param name="name">The name of the identity resource.</param>
+        /// <returns>A <see cref="StatusCodes.Status200OK"/> response containing the identity resource, or <see cref="StatusCodes.Status404NotFound"/> if it does not exist.</returns>
+        [HttpGet("by-name/{name}")]
+        [ProducesResponseType<IdentityResourceDto>(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public IActionResult GetByName(string name)
+        {
+            var entity = dbContext.IdentityResources.FirstOrDefault(r => r.Name == name);
+            return entity is null ? NotFound() : Ok(Mapper.Map<IdentityResourceDto>(entity));
+        }
+
         /// <summary>Creates a new identity resource.</summary>
         /// <param name="dto">The identity resource details to create.</param>
         /// <returns>A <see cref="StatusCodes.Status201Created"/> response containing the created identity resource, or <see cref="StatusCodes.Status400BadRequest"/> if the request is invalid.</returns>
@@ -139,10 +151,13 @@ namespace Spydersoft.Identity.Admin.Api.Controllers.V1
         [Authorize(Policy = AdminApiPolicies.Write)]
         [ProducesResponseType<IdentityResourceClaimDto>(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status409Conflict)]
         public async Task<IActionResult> Create(int identityResourceId, [FromBody] SaveIdentityResourceClaimDto dto)
         {
             var resource = await dbContext.IdentityResources.Include(r => r.UserClaims).FirstOrDefaultAsync(r => r.Id == identityResourceId);
             if (resource is null) return NotFound();
+            if (resource.UserClaims.Any(x => x.Type == dto.Type))
+                return Conflict($"A claim with type '{dto.Type}' already exists for this identity resource.");
             var entity = Mapper.Map<Duende.IdentityServer.EntityFramework.Entities.IdentityResourceClaim>(dto);
             entity.IdentityResourceId = identityResourceId;
             resource.UserClaims.Add(entity);
@@ -214,10 +229,13 @@ namespace Spydersoft.Identity.Admin.Api.Controllers.V1
         [Authorize(Policy = AdminApiPolicies.Write)]
         [ProducesResponseType<IdentityResourcePropertyDto>(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status409Conflict)]
         public async Task<IActionResult> Create(int identityResourceId, [FromBody] SaveIdentityResourcePropertyDto dto)
         {
             var resource = await dbContext.IdentityResources.Include(r => r.Properties).FirstOrDefaultAsync(r => r.Id == identityResourceId);
             if (resource is null) return NotFound();
+            if (resource.Properties.Any(x => x.Key == dto.Key))
+                return Conflict($"A property with key '{dto.Key}' already exists for this identity resource.");
             var entity = Mapper.Map<Duende.IdentityServer.EntityFramework.Entities.IdentityResourceProperty>(dto);
             entity.IdentityResourceId = identityResourceId;
             resource.Properties.Add(entity);

--- a/source/Spydersoft.Identity.Admin.Api/Controllers/V1/ScopeControllers.cs
+++ b/source/Spydersoft.Identity.Admin.Api/Controllers/V1/ScopeControllers.cs
@@ -41,6 +41,18 @@ namespace Spydersoft.Identity.Admin.Api.Controllers.V1
             return entity is null ? NotFound() : Ok(Mapper.Map<ScopeDto>(entity));
         }
 
+        /// <summary>Gets the API scope with the specified natural <c>Name</c> key.</summary>
+        /// <param name="name">The name of the scope.</param>
+        /// <returns>A <see cref="StatusCodes.Status200OK"/> response containing the scope, or <see cref="StatusCodes.Status404NotFound"/> if it does not exist.</returns>
+        [HttpGet("by-name/{name}")]
+        [ProducesResponseType<ScopeDto>(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        public IActionResult GetByName(string name)
+        {
+            var entity = dbContext.ApiScopes.FirstOrDefault(s => s.Name == name);
+            return entity is null ? NotFound() : Ok(Mapper.Map<ScopeDto>(entity));
+        }
+
         /// <summary>Creates a new API scope.</summary>
         /// <param name="dto">The scope details to create.</param>
         /// <returns>A <see cref="StatusCodes.Status201Created"/> response containing the created scope, or <see cref="StatusCodes.Status400BadRequest"/> if the request is invalid.</returns>
@@ -136,10 +148,13 @@ namespace Spydersoft.Identity.Admin.Api.Controllers.V1
         [Authorize(Policy = AdminApiPolicies.Write)]
         [ProducesResponseType<ScopeClaimDto>(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status409Conflict)]
         public async Task<IActionResult> Create(int scopeId, [FromBody] SaveScopeClaimDto dto)
         {
             var scope = await dbContext.ApiScopes.Include(s => s.UserClaims).FirstOrDefaultAsync(s => s.Id == scopeId);
             if (scope is null) return NotFound();
+            if (scope.UserClaims.Any(x => x.Type == dto.Type))
+                return Conflict($"A claim with type '{dto.Type}' already exists for this scope.");
             var entity = Mapper.Map<Duende.IdentityServer.EntityFramework.Entities.ApiScopeClaim>(dto);
             entity.ScopeId = scopeId;
             scope.UserClaims.Add(entity);
@@ -211,10 +226,13 @@ namespace Spydersoft.Identity.Admin.Api.Controllers.V1
         [Authorize(Policy = AdminApiPolicies.Write)]
         [ProducesResponseType<ScopePropertyDto>(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status409Conflict)]
         public async Task<IActionResult> Create(int scopeId, [FromBody] SaveScopePropertyDto dto)
         {
             var scope = await dbContext.ApiScopes.Include(s => s.Properties).FirstOrDefaultAsync(s => s.Id == scopeId);
             if (scope is null) return NotFound();
+            if (scope.Properties.Any(x => x.Key == dto.Key))
+                return Conflict($"A property with key '{dto.Key}' already exists for this scope.");
             var entity = Mapper.Map<Duende.IdentityServer.EntityFramework.Entities.ApiScopeProperty>(dto);
             entity.ScopeId = scopeId;
             scope.Properties.Add(entity);

--- a/source/Spydersoft.Identity.Admin.Api/Data/ApiAutoMapperProfile.cs
+++ b/source/Spydersoft.Identity.Admin.Api/Data/ApiAutoMapperProfile.cs
@@ -126,7 +126,7 @@ namespace Spydersoft.Identity.Admin.Api.Data
                 .ForMember(d => d.Client, opt => opt.Ignore())
                 .ForMember(d => d.ClientId, opt => opt.Ignore())
                 .ForMember(d => d.Created, opt => opt.Ignore())
-                .ForMember(d => d.Expiration, opt => opt.Ignore());
+                .ForMember(d => d.Expiration, opt => opt.MapFrom(src => string.IsNullOrEmpty(src.Expiration) ? (DateTime?)null : DateTime.Parse(src.Expiration, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.RoundtripKind)));
         }
 
         private void CreateApiResourceMappings()
@@ -177,7 +177,7 @@ namespace Spydersoft.Identity.Admin.Api.Data
                 .ForMember(d => d.ApiResource, opt => opt.Ignore())
                 .ForMember(d => d.ApiResourceId, opt => opt.Ignore())
                 .ForMember(d => d.Created, opt => opt.Ignore())
-                .ForMember(d => d.Expiration, opt => opt.Ignore());
+                .ForMember(d => d.Expiration, opt => opt.MapFrom(src => string.IsNullOrEmpty(src.Expiration) ? (DateTime?)null : DateTime.Parse(src.Expiration, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.RoundtripKind)));
         }
 
         private void CreateIdentityResourceMappings()

--- a/source/Spydersoft.Identity.DataSeeder/Seeding/Clients.cs
+++ b/source/Spydersoft.Identity.DataSeeder/Seeding/Clients.cs
@@ -18,6 +18,13 @@ internal static class Clients
     // real /connect/token endpoint. Do not reuse outside the tests project.
     public const string AdminTestsClientSecret = "local-tests-only-do-not-deploy";
 
+    // Cleartext secret for the `terraform-provider` client_credentials client.
+    // Committed deliberately — local-only dev fixture so the Terraform provider
+    // has a working client out of the box against a locally seeded instance.
+    // Production usage requires registering an equivalent client with its own
+    // secret via the admin API/UI; do not reuse this value outside local dev.
+    public const string TerraformProviderClientSecret = "local-dev-only-do-not-deploy";
+
     private static Secret Hashed(string hash) => new(hash) { Type = IdentityServerConstants.SecretTypes.SharedSecret };
 
     /// <param name="adminFrontendClientSecret">
@@ -126,6 +133,17 @@ internal static class Clients
             ClientName = "Identity Admin Tests",
             AllowedGrantTypes = { GrantType.ClientCredentials },
             ClientSecrets = { Hashed(AdminTestsClientSecret.Sha256()) },
+            AllowedScopes = { "identity:admin:read", "identity:admin:write" },
+        },
+        // Client_credentials client used by the Terraform/OpenTofu provider to
+        // manage clients/resources/scopes via the admin API. Secret is committed
+        // in source for local dev — see TerraformProviderClientSecret above.
+        new Client
+        {
+            ClientId = "terraform-provider",
+            ClientName = "Terraform Provider",
+            AllowedGrantTypes = { GrantType.ClientCredentials },
+            ClientSecrets = { Hashed(TerraformProviderClientSecret.Sha256()) },
             AllowedScopes = { "identity:admin:read", "identity:admin:write" },
         },
     };


### PR DESCRIPTION
## Summary
- Fix the `Expiration` field on client/API-resource secrets, which was accepted by the API but silently dropped by AutoMapper (`.Ignore()`) and never persisted.
- Add natural-key lookup endpoints — `GET .../clients/by-client-id/{clientId}`, `.../apiresources/by-name/{name}`, `.../identityresources/by-name/{name}`, `.../scopes/by-name/{name}` — so callers (e.g. `terraform import`) can resolve a human-meaningful key without pulling the full unpaginated collection.
- Add duplicate-prevention (`409 Conflict`) on value-keyed sub-resource creates (claims, CORS origins, grant types, IdP restrictions, post-logout redirect URIs, properties, redirect URIs, scopes) across Client/ApiResource/IdentityResource/Scope, so retried creates don't silently produce duplicate rows.
- Seed a `terraform-provider` client-credentials client in `DataSeeder`, mirroring the existing `identity.admin.tests` fixture, for local dev.

## Context
Scoping out a Terraform/OpenTofu provider for the admin API surfaced these as real correctness gaps (not just provider-side concerns) that would make `terraform import` and idempotent applies unreliable. One originally-suspected issue — that `PUT` silently ignores `null` fields instead of resetting them — was empirically verified *not* to be a bug (AutoMapper's default `Map(source, destination)` does perform a true full-replace), so no change was made there.

No changes to the admin UI or its OpenAPI client are needed — all changes are additive (new endpoints, corrected mapping, new 409 responses on previously-unconstrained creates).

## Test plan
- [x] Full solution builds (`dotnet build source/Spydersoft.Identity.slnx`) with 0 errors.
- [x] Pre-commit hook's `.NET` unit tests pass (2/2).
- [ ] `tests/admin-api-integration` Playwright suite (requires Docker for the Aspire-hosted Postgres, unavailable in the sandbox this PR was authored in — please run locally before merging).
- [ ] Manual pass through the admin UI's Client edit page (load/edit/save, add/remove a redirect URI and secret) to confirm no UI regression.