### PR TITLE
CI: exclude bin/obj from the solution-wide SonarCloud scan

### DIFF
--- a/.devops/pipeline-ci.yml
+++ b/.devops/pipeline-ci.yml
@@ -112,6 +112,12 @@ stages:
       sonarProjectName: identity_server
       useSonarCloud: true
       sonarCloudOrganization: spydersoft-mjg
+      # bin/obj carry copied build artifacts (e.g. stray tsconfig.json files from
+      # the TypeScript asset build) that the bundled JS/TS analyzer otherwise
+      # tries and fails to parse as real TS projects, even though the C#
+      # analyzer itself never looks at build output.
+      sonarExtraProperties: |
+        sonar.exclusions=**/bin/**,**/obj/**
 
       # admin-ui React SPA: yarn install/test/build (produces dist consumed by the
       # Admin.Frontend publish) plus its own SonarCloud scope for the JS/TS code.


### PR DESCRIPTION
## Summary
Build 6287's SonarCloudAnalyze step was logging 2 non-blocking errors (tsconfig.json parse failures under `bin/Release/net10.0/...`). Root cause: the JS/TS analyzer bundled in the .NET solution's SonarCloud scope filesystem-walks the repo independently of the C# analyzer's MSBuild-driven scan, so it was picking up stray `tsconfig.json` copies left in build output and failing to parse them (no matching `.ts` sources exist there). This doesn't fail the pipeline but adds noise to every build.

Adds `sonar.exclusions=**/bin/**,**/obj/**` via the existing `sonarExtraProperties` parameter on the shared `build-multi-container` template, which feeds straight into `SonarCloudPrepare@3`.

## Test plan
- [x] YAML parses correctly; `sonarExtraProperties` resolves to `sonar.exclusions=**/bin/**,**/obj/**`.
- [ ] Next CI run on this branch should show the SonarCloudAnalyze step with 0 errors.