### PR TITLE
Authenticate GitHub Packages feed in integration-tests stage

### DIFF
--- a/.devops/pipeline-ci.yml
+++ b/.devops/pipeline-ci.yml
@@ -187,6 +187,11 @@ stages:
         - Build
       netCoreVersion: '10.0.x'
       nodeVersion: '22.x'
+      # Admin API Integration's webServer boots via `dotnet run`, which triggers
+      # an implicit restore against the private spydersoft GitHub Packages feed
+      # (see nuget.config) -- same service connection as the Build stage's
+      # externalFeedCredentials, above.
+      externalFeedCredentials: SpydersoftGithub
       setupSteps:
         # UseNode@1 (used by this template to set up Node) mis-resolves "22.x" to a
         # stale cached Node 10 on our self-hosted agent, which breaks corepack. Force


### PR DESCRIPTION
Admin API Integration's Playwright webServer boots via dotnet run, which implicitly restores against the private spydersoft GitHub Packages feed. That job never authenticates on its own, causing 401s. Pass the same service connection the Build stage uses.