### PR TITLE
Fix admin UI: adding a client secret (or other sub-resource) silently failed

### DIFF
--- a/.devops/pipeline-ci.yml
+++ b/.devops/pipeline-ci.yml
@@ -187,6 +187,11 @@ stages:
         - Build
       netCoreVersion: '10.0.x'
       nodeVersion: '22.x'
+      # Admin API Integration's webServer boots via `dotnet run`, which triggers
+      # an implicit restore against the private spydersoft GitHub Packages feed
+      # (see nuget.config) -- same service connection as the Build stage's
+      # externalFeedCredentials, above.
+      externalFeedCredentials: SpydersoftGithub
       setupSteps:
         # UseNode@1 (used by this template to set up Node) mis-resolves "22.x" to a
         # stale cached Node 10 on our self-hosted agent, which breaks corepack. Force

--- a/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/clients/ClientSubResources.tsx
+++ b/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/clients/ClientSubResources.tsx
@@ -57,6 +57,19 @@ import type {
 // standard "offline_access" scope, since clients can't define new scopes here.
 const STANDARD_SCOPES = ["offline_access"];
 
+// Extracts a human-readable message from an ASP.NET ProblemDetails/ValidationProblemDetails
+// error body so failed creates can be surfaced instead of failing silently.
+function problemMessage(error: unknown, fallback: string): string {
+  if (error && typeof error === "object") {
+    const e = error as { detail?: string; title?: string; errors?: Record<string, string[]> };
+    const firstValidationError = e.errors && Object.values(e.errors)[0]?.[0];
+    if (firstValidationError) return firstValidationError;
+    if (e.detail) return e.detail;
+    if (e.title) return e.title;
+  }
+  return fallback;
+}
+
 interface PanelProps {
   clientId: number;
 }
@@ -86,6 +99,7 @@ function SingleValuePanel<T extends { id?: number | string }>({
   describe: (row: T) => string;
 }) {
   const columns: SubResourceColumn<T>[] = [{ field, header }];
+  const [error, setError] = useState<string | null>(null);
 
   return (
     <SubResourceList<T, { value: string }>
@@ -99,26 +113,34 @@ function SingleValuePanel<T extends { id?: number | string }>({
       renderCreateForm={({ onCreated, createDraft, setCreateDraft }) => {
         const submit = async () => {
           if (!createDraft.value.trim()) return;
-          await create(createDraft.value.trim());
-          onCreated();
+          setError(null);
+          try {
+            await create(createDraft.value.trim());
+            onCreated();
+          } catch (e) {
+            setError(problemMessage(e, "Failed to add."));
+          }
         };
         return (
-          <div className="flex gap-2">
-            <InputText
-              type={fieldType}
-              className="flex-1"
-              value={createDraft.value}
-              placeholder={placeholder}
-              onChange={(e) => setCreateDraft({ value: e.target.value })}
-              onKeyDown={(e) => e.key === "Enter" && submit()}
-            />
-            <Button
-              type="button"
-              onClick={submit}
-              label="Add"
-              icon={<FontAwesomeIcon icon={faPlus} />}
-              disabled={!createDraft.value.trim()}
-            />
+          <div>
+            <div className="flex gap-2">
+              <InputText
+                type={fieldType}
+                className="flex-1"
+                value={createDraft.value}
+                placeholder={placeholder}
+                onChange={(e) => setCreateDraft({ value: e.target.value })}
+                onKeyDown={(e) => e.key === "Enter" && submit()}
+              />
+              <Button
+                type="button"
+                onClick={submit}
+                label="Add"
+                icon={<FontAwesomeIcon icon={faPlus} />}
+                disabled={!createDraft.value.trim()}
+              />
+            </div>
+            {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
           </div>
         );
       }}
@@ -158,6 +180,7 @@ function KeyValuePanel<T extends { id?: number | string }>({
     { field: keyField, header: keyHeader },
     { field: valueField, header: valueHeader },
   ];
+  const [error, setError] = useState<string | null>(null);
 
   return (
     <SubResourceList<T, { key: string; value: string }>
@@ -171,32 +194,40 @@ function KeyValuePanel<T extends { id?: number | string }>({
       renderCreateForm={({ onCreated, createDraft, setCreateDraft }) => {
         const submit = async () => {
           if (!createDraft.key.trim() || !createDraft.value.trim()) return;
-          await create(createDraft.key.trim(), createDraft.value.trim());
-          onCreated();
+          setError(null);
+          try {
+            await create(createDraft.key.trim(), createDraft.value.trim());
+            onCreated();
+          } catch (e) {
+            setError(problemMessage(e, "Failed to add."));
+          }
         };
         return (
-          <div className="flex gap-2">
-            <InputText
-              className="flex-1"
-              value={createDraft.key}
-              placeholder={keyPlaceholder}
-              onChange={(e) => setCreateDraft({ ...createDraft, key: e.target.value })}
-              onKeyDown={(e) => e.key === "Enter" && submit()}
-            />
-            <InputText
-              className="flex-1"
-              value={createDraft.value}
-              placeholder={valuePlaceholder}
-              onChange={(e) => setCreateDraft({ ...createDraft, value: e.target.value })}
-              onKeyDown={(e) => e.key === "Enter" && submit()}
-            />
-            <Button
-              type="button"
-              onClick={submit}
-              label="Add"
-              icon={<FontAwesomeIcon icon={faPlus} />}
-              disabled={!createDraft.key.trim() || !createDraft.value.trim()}
-            />
+          <div>
+            <div className="flex gap-2">
+              <InputText
+                className="flex-1"
+                value={createDraft.key}
+                placeholder={keyPlaceholder}
+                onChange={(e) => setCreateDraft({ ...createDraft, key: e.target.value })}
+                onKeyDown={(e) => e.key === "Enter" && submit()}
+              />
+              <InputText
+                className="flex-1"
+                value={createDraft.value}
+                placeholder={valuePlaceholder}
+                onChange={(e) => setCreateDraft({ ...createDraft, value: e.target.value })}
+                onKeyDown={(e) => e.key === "Enter" && submit()}
+              />
+              <Button
+                type="button"
+                onClick={submit}
+                label="Add"
+                icon={<FontAwesomeIcon icon={faPlus} />}
+                disabled={!createDraft.key.trim() || !createDraft.value.trim()}
+              />
+            </div>
+            {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
           </div>
         );
       }}
@@ -220,7 +251,8 @@ export function ClaimsPanel({ clientId }: PanelProps) {
         return r.error ? [] : (r.data ?? []);
       }}
       create={async (type, value) => {
-        await postApiV1ClientsByClientIdClaims({ path: { clientId }, body: { type, value } });
+        const r = await postApiV1ClientsByClientIdClaims({ path: { clientId }, body: { type, value } });
+        if (r.error) throw r.error;
       }}
       remove={async (id) => {
         await deleteApiV1ClientsByClientIdClaimsById({ path: { clientId, id } });
@@ -244,7 +276,8 @@ export function CorsOriginsPanel({ clientId }: PanelProps) {
         return r.error ? [] : (r.data ?? []);
       }}
       create={async (origin) => {
-        await postApiV1ClientsByClientIdCorsorigins({ path: { clientId }, body: { origin } });
+        const r = await postApiV1ClientsByClientIdCorsorigins({ path: { clientId }, body: { origin } });
+        if (r.error) throw r.error;
       }}
       remove={async (id) => {
         await deleteApiV1ClientsByClientIdCorsoriginsById({ path: { clientId, id } });
@@ -267,7 +300,8 @@ export function GrantTypesPanel({ clientId }: PanelProps) {
         return r.error ? [] : (r.data ?? []);
       }}
       create={async (grantType) => {
-        await postApiV1ClientsByClientIdGranttypes({ path: { clientId }, body: { grantType } });
+        const r = await postApiV1ClientsByClientIdGranttypes({ path: { clientId }, body: { grantType } });
+        if (r.error) throw r.error;
       }}
       remove={async (id) => {
         await deleteApiV1ClientsByClientIdGranttypesById({ path: { clientId, id } });
@@ -290,7 +324,8 @@ export function IdpRestrictionsPanel({ clientId }: PanelProps) {
         return r.error ? [] : (r.data ?? []);
       }}
       create={async (provider) => {
-        await postApiV1ClientsByClientIdIdprestrictions({ path: { clientId }, body: { provider } });
+        const r = await postApiV1ClientsByClientIdIdprestrictions({ path: { clientId }, body: { provider } });
+        if (r.error) throw r.error;
       }}
       remove={async (id) => {
         await deleteApiV1ClientsByClientIdIdprestrictionsById({ path: { clientId, id } });
@@ -314,10 +349,11 @@ export function PostLogoutRedirectUrisPanel({ clientId }: PanelProps) {
         return r.error ? [] : (r.data ?? []);
       }}
       create={async (postLogoutRedirectUri) => {
-        await postApiV1ClientsByClientIdPostlogoutredirecturis({
+        const r = await postApiV1ClientsByClientIdPostlogoutredirecturis({
           path: { clientId },
           body: { postLogoutRedirectUri },
         });
+        if (r.error) throw r.error;
       }}
       remove={async (id) => {
         await deleteApiV1ClientsByClientIdPostlogoutredirecturisById({ path: { clientId, id } });
@@ -341,7 +377,8 @@ export function PropertiesPanel({ clientId }: PanelProps) {
         return r.error ? [] : (r.data ?? []);
       }}
       create={async (key, value) => {
-        await postApiV1ClientsByClientIdProperties({ path: { clientId }, body: { key, value } });
+        const r = await postApiV1ClientsByClientIdProperties({ path: { clientId }, body: { key, value } });
+        if (r.error) throw r.error;
       }}
       remove={async (id) => {
         await deleteApiV1ClientsByClientIdPropertiesById({ path: { clientId, id } });
@@ -365,7 +402,8 @@ export function RedirectUrisPanel({ clientId }: PanelProps) {
         return r.error ? [] : (r.data ?? []);
       }}
       create={async (redirectUri) => {
-        await postApiV1ClientsByClientIdRedirecturis({ path: { clientId }, body: { redirectUri } });
+        const r = await postApiV1ClientsByClientIdRedirecturis({ path: { clientId }, body: { redirectUri } });
+        if (r.error) throw r.error;
       }}
       remove={async (id) => {
         await deleteApiV1ClientsByClientIdRedirecturisById({ path: { clientId, id } });
@@ -381,6 +419,7 @@ export function ScopesPanel({ clientId }: PanelProps) {
   const [selected, setSelected] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [adding, setAdding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -427,8 +466,13 @@ export function ScopesPanel({ clientId }: PanelProps) {
   const handleAdd = async () => {
     if (!selected) return;
     setAdding(true);
+    setError(null);
     try {
-      await postApiV1ClientsByClientIdScopes({ path: { clientId }, body: { scope: selected } });
+      const r = await postApiV1ClientsByClientIdScopes({ path: { clientId }, body: { scope: selected } });
+      if (r.error) {
+        setError(problemMessage(r.error, "Failed to add scope."));
+        return;
+      }
       setSelected(null);
       await refresh();
     } finally {
@@ -493,6 +537,7 @@ export function ScopesPanel({ clientId }: PanelProps) {
             loading={adding}
           />
         </div>
+        {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
       </div>
     </div>
   );
@@ -502,6 +547,7 @@ export function ScopesPanel({ clientId }: PanelProps) {
 export function SecretsPanel({ clientId }: PanelProps) {
   const [draft, setDraft] = useState<SaveClientSecretDto>({ type: "SharedSecret", value: "" });
   const emptyDraft: SaveClientSecretDto = { type: "SharedSecret", value: "" };
+  const [error, setError] = useState<string | null>(null);
 
   return (
     <SubResourceList<ClientSecretDto, SaveClientSecretDto>
@@ -524,7 +570,12 @@ export function SecretsPanel({ clientId }: PanelProps) {
       renderCreateForm={({ onCreated }) => {
         const submit = async () => {
           if (!draft.type.trim() || !draft.value.trim()) return;
-          await postApiV1ClientsByClientIdSecrets({ path: { clientId }, body: draft });
+          setError(null);
+          const r = await postApiV1ClientsByClientIdSecrets({ path: { clientId }, body: draft });
+          if (r.error) {
+            setError(problemMessage(r.error, "Failed to add secret."));
+            return;
+          }
           setDraft(emptyDraft);
           onCreated();
         };
@@ -555,6 +606,7 @@ export function SecretsPanel({ clientId }: PanelProps) {
                 disabled={!draft.type.trim() || !draft.value.trim()}
               />
             </div>
+            {error && <p className="text-sm text-red-600 md:col-span-2">{error}</p>}
           </div>
         );
       }}


### PR DESCRIPTION
## Summary
- Every sub-resource create handler (secrets, claims, CORS origins, grant types, IdP restrictions, post-logout URIs, properties, redirect URIs, scopes) awaited the generated API client's POST call without checking `.error`. Since the client resolves rather than throws on failed requests, a rejected create (validation error, missing write scope, etc.) still cleared the form and refreshed the list — making it look like the add succeeded when nothing was persisted.
- Failures are now surfaced inline under each create form, and the form only resets on a real success.

## Test plan
- [x] `tsc --noEmit` passes with no errors
- [ ] Manually add a client secret in the admin UI and confirm it now persists (or shows a clear error if it doesn't)
- [ ] Manually add a claim / CORS origin / redirect URI etc. and confirm the same