### PR TITLE
Apply logging standard and upgrade Spydersoft.Platform.Hosting to 3.1.0

### DIFF
--- a/source/Directory.Packages.props
+++ b/source/Directory.Packages.props
@@ -33,7 +33,7 @@
     <PackageVersion Include="Npgsql.OpenTelemetry" Version="10.0.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.15.1" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.23.0.137933" />
-    <PackageVersion Include="Spydersoft.Platform.Hosting" Version="2.3.0" />
+    <PackageVersion Include="Spydersoft.Platform.Hosting" Version="3.1.0" />
 
     <!-- Test Project Packages -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />

--- a/source/Spydersoft.Identity.Admin.Api/Program.cs
+++ b/source/Spydersoft.Identity.Admin.Api/Program.cs
@@ -153,6 +153,7 @@ try
 
     _ = app.UseSpydersoftHealthChecks(healthCheckOptions)
             .UseRouting()
+            .UseSpydersoftRequestLogging()
             .UseAuthentication()
             .UseAuthorization();
 

--- a/source/Spydersoft.Identity.Admin.Api/appsettings.Development.json
+++ b/source/Spydersoft.Identity.Admin.Api/appsettings.Development.json
@@ -5,7 +5,8 @@
       "Override": {
         "Microsoft": "Information",
         "Microsoft.AspNetCore": "Warning",
-        "System": "Warning"
+        "System": "Warning",
+        "Spydersoft.Identity.Admin.Api": "Debug"
       }
     }
   }

--- a/source/Spydersoft.Identity.Admin.Api/appsettings.json
+++ b/source/Spydersoft.Identity.Admin.Api/appsettings.json
@@ -20,7 +20,9 @@
       "Default": "Warning",
       "Override": {
         "Microsoft": "Error",
-        "System": "Error"
+        "Microsoft.AspNetCore": "Warning",
+        "System": "Error",
+        "Spydersoft.Identity.Admin.Api": "Information"
       }
     }
   },

--- a/source/Spydersoft.Identity.Admin.Frontend/Program.cs
+++ b/source/Spydersoft.Identity.Admin.Frontend/Program.cs
@@ -57,6 +57,7 @@ app.UseForwardedHeaders(forwardedHeadersOptions);
 app.UseSpydersoftHealthChecks(healthCheckOptions);
 
 app.UseRouting();
+app.UseSpydersoftRequestLogging();
 app.UseOidcProxy();
 app.UseDefaultFiles();
 app.UseStaticFiles();

--- a/source/Spydersoft.Identity.Admin.Frontend/appsettings.json
+++ b/source/Spydersoft.Identity.Admin.Frontend/appsettings.json
@@ -35,18 +35,15 @@
     }
   },
   "AllowedHosts": "*",
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  },
   "Serilog": {
     "MinimumLevel": {
       "Default": "Warning",
       "Override": {
         "Microsoft": "Error",
-        "System": "Error"
+        "Microsoft.AspNetCore": "Warning",
+        "System": "Error",
+        "OidcProxy.Net": "Information",
+        "Yarp.ReverseProxy": "Information"
       }
     }
   },

--- a/source/Spydersoft.Identity.Data/Data/DatabaseInitializer.cs
+++ b/source/Spydersoft.Identity.Data/Data/DatabaseInitializer.cs
@@ -31,9 +31,9 @@ namespace Spydersoft.Identity.Data
         /// </summary>
         private readonly IApplicationBuilder _app = app;
         /// <summary>
-        /// The log
+        /// The logger
         /// </summary>
-        private ILogger _log = null!;
+        private ILogger _logger = null!;
 
         /// <summary>
         /// Initializes the database.
@@ -41,7 +41,7 @@ namespace Spydersoft.Identity.Data
         public void InitializeDatabase()
         {
             using IServiceScope serviceScope = _app.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope();
-            _log = serviceScope.ServiceProvider.GetRequiredService<ILogger<DatabaseInitializer>>();
+            _logger = serviceScope.ServiceProvider.GetRequiredService<ILogger<DatabaseInitializer>>();
 
             PerformDatabaseMigrations(serviceScope);
             SeedDatabase(serviceScope);
@@ -75,11 +75,11 @@ namespace Spydersoft.Identity.Data
         /// <returns>System.Threading.Tasks.Task.</returns>
         private async Task DoMigrationIfNeeded(DbContext context, string databaseName)
         {
-            _log.LogDebug("Checking {Database} for pending migrations.", databaseName);
+            _logger.LogDebug("Checking {Database} for pending migrations.", databaseName);
             var hasMigrations = (await context.Database.GetPendingMigrationsAsync()).Any();
             if (hasMigrations)
             {
-                _log.LogInformation("Migrating {Database}.", databaseName);
+                _logger.LogInformation("Migrating {Database}.", databaseName);
                 await context.Database.MigrateAsync();
             }
         }
@@ -108,7 +108,7 @@ namespace Spydersoft.Identity.Data
 
             if (!context.Clients.Any())
             {
-                _log.LogInformation("No Clients Found. Creating sample Clients");
+                _logger.LogInformation("No Clients Found. Creating sample Clients");
                 foreach (Client client in GetClients())
                 {
                     _ = context.Clients.Add(client.ToEntity());
@@ -120,7 +120,7 @@ namespace Spydersoft.Identity.Data
             // Ensure all standard identity resources exist
             foreach (IdentityResource resource in GetIdentityResources().Where(resource => !context.IdentityResources.Any(ir => ir.Name == resource.Name)))
             {
-                _log.LogInformation("Identity Resource {ResourceName} not found. Creating it.", resource.Name);
+                _logger.LogInformation("Identity Resource {ResourceName} not found. Creating it.", resource.Name);
                 _ = context.IdentityResources.Add(resource.ToEntity());
             }
             _ = context.SaveChanges();
@@ -128,7 +128,7 @@ namespace Spydersoft.Identity.Data
             // Ensure all standard API resources exist
             foreach (ApiResource resource in GetApiResources().Where(resource => !context.ApiResources.Any(ar => ar.Name == resource.Name)))
             {
-                _log.LogInformation("API Resource {ResourceName} not found. Creating it.", resource.Name);
+                _logger.LogInformation("API Resource {ResourceName} not found. Creating it.", resource.Name);
                 _ = context.ApiResources.Add(resource.ToEntity());
             }
             _ = context.SaveChanges();
@@ -185,11 +185,11 @@ namespace Spydersoft.Identity.Data
                     throw new IdentityResultException(result);
                 }
 
-                _log.LogInformation("admin created");
+                _logger.LogInformation("admin created");
             }
             else
             {
-                _log.LogDebug("admin already exists");
+                _logger.LogDebug("admin already exists");
             }
 
         }
@@ -205,7 +205,7 @@ namespace Spydersoft.Identity.Data
             IdentityResult result = roleMgr.CreateAsync(new ApplicationRole { Name = roleName }).Result;
             if (!result.Succeeded)
             {
-                _log.LogError("Unable to create {Role} role : {Error}", roleName, result.ToString());
+                _logger.LogError("Unable to create {Role} role : {Error}", roleName, result.ToString());
             }
         }
 

--- a/source/Spydersoft.Identity/Program.cs
+++ b/source/Spydersoft.Identity/Program.cs
@@ -222,17 +222,6 @@ try
 
     _ = app.UseForwardedHeaders(forwardedHeadersOptions);
 
-    // Log the scheme being used for debugging (can be removed in production)
-    app.Use(async (context, next) =>
-    {
-        Log.Debug("Request - Scheme: {Scheme}, Host: {Host}, Path: {Path}, Proto Header: {Proto}",
-            context.Request.Scheme,
-            context.Request.Host,
-            context.Request.Path,
-            context.Request.Headers["X-Forwarded-Proto"].ToString());
-        await next();
-    });
-
     // this will do the initial DB population, but we only need to do it once
     // this is just in here as a easy, yet hacky, way to get our DB created/populated
     var dbInitialize = new DatabaseInitializer(app);
@@ -254,6 +243,7 @@ try
             .UseCookiePolicy()
             .UseStaticFiles()
             .UseRouting()
+            .UseSpydersoftRequestLogging()
             .UseAuthentication()
             .UseIdentityServer()
             .UseAuthorization();

--- a/source/Spydersoft.Identity/appsettings.Development.json
+++ b/source/Spydersoft.Identity/appsettings.Development.json
@@ -3,9 +3,6 @@
     "IdentityConnection": ""
   },
   "Logging": {
-    "LogLevel": {
-      "Default": "Information"
-    },
     "OpenTelemetry": {
       "IncludeFormattedMessage": true,
       "IncludeScopes": true,
@@ -14,16 +11,18 @@
   },
   "Serilog": {
     "MinimumLevel": {
-      "Default": "Debug",
+      "Default": "Warning",
       "Override": {
-        "Microsoft": "Debug",
-        "System": "Debug"
+        "Microsoft": "Warning",
+        "Microsoft.AspNetCore": "Warning",
+        "System": "Warning",
+        "Spydersoft.Identity": "Debug"
       }
     }
   },
   "Telemetry": {
     "Log": {
-      "Type": "console"
+      "Type": "none"
     },
     "Metrics": {
       "Type": "console"

--- a/source/Spydersoft.Identity/appsettings.json
+++ b/source/Spydersoft.Identity/appsettings.json
@@ -28,7 +28,9 @@
       "Default": "Warning",
       "Override": {
         "Microsoft": "Error",
-        "System": "Error"
+        "Microsoft.AspNetCore": "Warning",
+        "System": "Error",
+        "Spydersoft.Identity": "Information"
       }
     }
   },


### PR DESCRIPTION
## Summary
- Upgrade `Spydersoft.Platform.Hosting` to 3.1.0, picking up the duplicate-console-log-emission fix (`ClearProviders()`) and the `UseSpydersoftRequestLogging()` wrapper from `spydersoft-consulting/platform` ([PR #22](https://github.com/spydersoft-consulting/platform/pull/22)).
- Apply the internal logging standard (`D:\spydersoft\plans\logging-standards.md`) to all three apps (Identity, Admin.Api, Admin.Frontend):
  - Explicit `Serilog:MinimumLevel:Override` entries for `Microsoft.AspNetCore` and each app's own root namespace, so app logs are visible without framework request-diagnostics noise at `Information`.
  - Removed dead `Logging:LogLevel` sections (`Serilog:MinimumLevel` is the only level control on this stack).
  - Fixed Identity's Development `Telemetry:Log:Type` from `console` to `none` — it was duplicating every log line alongside Serilog's own console sink.
  - Added `UseSpydersoftRequestLogging()` to all three middleware pipelines for one structured per-request log line.
  - Removed the ad hoc static `Log.Debug(...)` request-scheme middleware in Identity's `Program.cs`, superseded by request logging.
  - Renamed `DatabaseInitializer`'s `_log` field to `_logger` for naming consistency.

## Test plan
- [x] `dotnet build` clean for all four affected projects, including against the new package version
- [x] `dotnet test` passes
- [ ] Deploy to Test and confirm console log lines are no longer duplicated and Grafana/Loki log volume drops as expected