### PR TITLE
Replace free-text inputs with known-value dropdowns in admin UI

### DIFF
--- a/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/api-resources/ApiResourceSubResources.tsx
+++ b/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/api-resources/ApiResourceSubResources.tsx
@@ -1,11 +1,14 @@
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { DataTable } from "primereact/datatable";
+import { Column } from "primereact/column";
 import { InputText } from "primereact/inputtext";
 import { InputTextarea } from "primereact/inputtextarea";
 import { Dropdown } from "primereact/dropdown";
 import { Calendar } from "primereact/calendar";
 import { Button } from "primereact/button";
+import { ConfirmDialog, confirmDialog } from "primereact/confirmdialog";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faPlus } from "@fortawesome/free-solid-svg-icons";
+import { faPlus, faTrash } from "@fortawesome/free-solid-svg-icons";
 
 import SubResourceList, { type SubResourceColumn } from "../../components/SubResourceList";
 import {
@@ -17,6 +20,7 @@ import {
   getApiV1ApiresourcesByApiResourceIdProperties,
   getApiV1ApiresourcesByApiResourceIdScopes,
   getApiV1ApiresourcesByApiResourceIdSecrets,
+  getApiV1Scopes,
   postApiV1ApiresourcesByApiResourceIdClaims,
   postApiV1ApiresourcesByApiResourceIdProperties,
   postApiV1ApiresourcesByApiResourceIdScopes,
@@ -30,6 +34,7 @@ import type {
   SaveApiResourceSecretDto,
 } from "../../api/generated/types.gen";
 import { SECRET_TYPES, validateSecretValue } from "../../utils/secretTypes";
+import { CLAIM_TYPES } from "../../utils/knownValues";
 import { problemMessage } from "../../utils/apiError";
 
 interface PanelProps {
@@ -42,21 +47,24 @@ function SingleValuePanel<T extends { id?: number | string }>({
   field,
   header,
   placeholder,
+  options,
   load,
   create,
   remove,
   describe,
-}: {
+}: Readonly<{
   title: string;
   emptyMessage: string;
   field: keyof T & string;
   header: string;
   placeholder?: string;
+  /** When provided, renders an editable dropdown of known values instead of a plain text input. */
+  options?: string[];
   load: () => Promise<T[]>;
   create: (value: string) => Promise<void>;
   remove: (id: number) => Promise<void>;
   describe: (row: T) => string;
-}) {
+}>) {
   const columns: SubResourceColumn<T>[] = [{ field, header }];
 
   return (
@@ -76,13 +84,24 @@ function SingleValuePanel<T extends { id?: number | string }>({
         };
         return (
           <div className="flex gap-2">
-            <InputText
-              className="flex-1"
-              value={createDraft.value}
-              placeholder={placeholder}
-              onChange={(e) => setCreateDraft({ value: e.target.value })}
-              onKeyDown={(e) => e.key === "Enter" && submit()}
-            />
+            {options ? (
+              <Dropdown
+                editable
+                className="flex-1"
+                value={createDraft.value}
+                options={options}
+                placeholder={placeholder}
+                onChange={(e) => setCreateDraft({ value: e.value ?? "" })}
+              />
+            ) : (
+              <InputText
+                className="flex-1"
+                value={createDraft.value}
+                placeholder={placeholder}
+                onChange={(e) => setCreateDraft({ value: e.target.value })}
+                onKeyDown={(e) => e.key === "Enter" && submit()}
+              />
+            )}
             <Button
               type="button"
               onClick={submit}
@@ -97,7 +116,7 @@ function SingleValuePanel<T extends { id?: number | string }>({
   );
 }
 
-export function ClaimsPanel({ apiResourceId }: PanelProps) {
+export function ClaimsPanel({ apiResourceId }: Readonly<PanelProps>) {
   return (
     <SingleValuePanel<ApiResourceClaimDto>
       title="User claims"
@@ -105,6 +124,7 @@ export function ClaimsPanel({ apiResourceId }: PanelProps) {
       field="type"
       header="Type"
       placeholder="email"
+      options={CLAIM_TYPES}
       load={async () => {
         const r = await getApiV1ApiresourcesByApiResourceIdClaims({ path: { apiResourceId } });
         return r.error ? [] : (r.data ?? []);
@@ -123,29 +143,131 @@ export function ClaimsPanel({ apiResourceId }: PanelProps) {
   );
 }
 
-export function ScopesPanel({ apiResourceId }: PanelProps) {
+export function ScopesPanel({ apiResourceId }: Readonly<PanelProps>) {
+  const [assigned, setAssigned] = useState<ApiResourceScopeDto[]>([]);
+  const [allScopeNames, setAllScopeNames] = useState<string[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [adding, setAdding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    const [assignedResult, apiScopesResult] = await Promise.all([
+      getApiV1ApiresourcesByApiResourceIdScopes({ path: { apiResourceId } }),
+      getApiV1Scopes(),
+    ]);
+    if (!assignedResult.error) setAssigned(assignedResult.data ?? []);
+    const names = new Set<string>();
+    for (const s of apiScopesResult.data ?? []) if (s.name) names.add(s.name);
+    setAllScopeNames([...names].sort((a, b) => a.localeCompare(b)));
+    setLoading(false);
+  }, [apiResourceId]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const assignedNames = new Set(assigned.map((s) => s.scope));
+  const available = allScopeNames
+    .filter((name) => !assignedNames.has(name))
+    .map((name) => ({ label: name, value: name }));
+
+  const handleDelete = (row: ApiResourceScopeDto) => {
+    confirmDialog({
+      message: (
+        <span>
+          Remove scope <strong>{row.scope}</strong>?
+        </span>
+      ),
+      header: "Confirm removal",
+      acceptClassName: "p-button-danger",
+      acceptLabel: "Remove",
+      rejectLabel: "Cancel",
+      accept: async () => {
+        await deleteApiV1ApiresourcesByApiResourceIdScopesById({ path: { apiResourceId, id: Number(row.id) } });
+        await refresh();
+      },
+    });
+  };
+
+  const handleAdd = async () => {
+    if (!selected) return;
+    setAdding(true);
+    setError(null);
+    try {
+      const r = await postApiV1ApiresourcesByApiResourceIdScopes({ path: { apiResourceId }, body: { scope: selected } });
+      if (r.error) {
+        setError(problemMessage(r.error, "Failed to add scope."));
+        return;
+      }
+      setSelected(null);
+      await refresh();
+    } finally {
+      setAdding(false);
+    }
+  };
+
   return (
-    <SingleValuePanel<ApiResourceScopeDto>
-      title="Scopes"
-      emptyMessage="No scopes associated with this API."
-      field="scope"
-      header="Scope"
-      placeholder="my.api.read"
-      load={async () => {
-        const r = await getApiV1ApiresourcesByApiResourceIdScopes({ path: { apiResourceId } });
-        return r.error ? [] : (r.data ?? []);
-      }}
-      create={async (scope) => {
-        await postApiV1ApiresourcesByApiResourceIdScopes({
-          path: { apiResourceId },
-          body: { scope },
-        });
-      }}
-      remove={async (id) => {
-        await deleteApiV1ApiresourcesByApiResourceIdScopesById({ path: { apiResourceId, id } });
-      }}
-      describe={(row) => row.scope ?? ""}
-    />
+    <div className="overflow-hidden rounded-xl border border-border bg-surface shadow-sm">
+      <ConfirmDialog />
+
+      <header className="flex items-baseline justify-between gap-3 border-b border-border px-5 py-3.5">
+        <div>
+          <h3 className="text-sm font-semibold text-content">Scopes</h3>
+          <p className="mt-0.5 text-xs text-content-muted">
+            {loading ? "Loading…" : `${assigned.length} ${assigned.length === 1 ? "entry" : "entries"}`}
+          </p>
+        </div>
+      </header>
+
+      <DataTable value={assigned} loading={loading} dataKey="id" emptyMessage="No scopes associated with this API." size="small">
+        <Column field="scope" header="Scope" />
+        <Column
+          header=""
+          style={{ width: "4.5rem" }}
+          body={(row: ApiResourceScopeDto) => (
+            <div className="flex justify-end">
+              <Button
+                text
+                rounded
+                size="small"
+                severity="danger"
+                aria-label="Delete"
+                icon={<FontAwesomeIcon icon={faTrash} />}
+                onClick={() => handleDelete(row)}
+              />
+            </div>
+          )}
+        />
+      </DataTable>
+
+      <div className="border-t border-border bg-surface-muted px-5 py-4">
+        <h4 className="mb-3 text-xs font-semibold uppercase tracking-wider text-content-muted">
+          Add new
+        </h4>
+        <div className="flex gap-2">
+          <Dropdown
+            value={selected}
+            options={available}
+            onChange={(e) => setSelected(e.value as string)}
+            placeholder={available.length === 0 ? "All scopes already added" : "Select a scope"}
+            disabled={available.length === 0}
+            filter
+            className="flex-1"
+          />
+          <Button
+            type="button"
+            onClick={handleAdd}
+            label="Add"
+            icon={<FontAwesomeIcon icon={faPlus} />}
+            disabled={!selected || adding}
+            loading={adding}
+          />
+        </div>
+        {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+      </div>
+    </div>
   );
 }
 

--- a/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/clients/ClientSubResources.tsx
+++ b/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/clients/ClientSubResources.tsx
@@ -55,6 +55,7 @@ import type {
   SaveClientSecretDto,
 } from "../../api/generated/types.gen";
 import { SECRET_TYPES, validateSecretValue } from "../../utils/secretTypes";
+import { GRANT_TYPES, IDP_PROVIDERS } from "../../utils/knownValues";
 import { problemMessage } from "../../utils/apiError";
 
 // Scopes are drawn from existing API scopes / identity resources plus the
@@ -73,6 +74,7 @@ function SingleValuePanel<T extends { id?: number | string }>({
   header,
   fieldType = "text",
   placeholder,
+  options,
   load,
   create,
   remove,
@@ -84,6 +86,8 @@ function SingleValuePanel<T extends { id?: number | string }>({
   header: string;
   fieldType?: "text" | "url";
   placeholder?: string;
+  /** When provided, renders an editable dropdown of known values instead of a plain text input. */
+  options?: string[];
   load: () => Promise<T[]>;
   create: (value: string) => Promise<void>;
   remove: (id: number) => Promise<void>;
@@ -115,14 +119,25 @@ function SingleValuePanel<T extends { id?: number | string }>({
         return (
           <div>
             <div className="flex gap-2">
-              <InputText
-                type={fieldType}
-                className="flex-1"
-                value={createDraft.value}
-                placeholder={placeholder}
-                onChange={(e) => setCreateDraft({ value: e.target.value })}
-                onKeyDown={(e) => e.key === "Enter" && submit()}
-              />
+              {options ? (
+                <Dropdown
+                  editable
+                  className="flex-1"
+                  value={createDraft.value}
+                  options={options}
+                  placeholder={placeholder}
+                  onChange={(e) => setCreateDraft({ value: e.value ?? "" })}
+                />
+              ) : (
+                <InputText
+                  type={fieldType}
+                  className="flex-1"
+                  value={createDraft.value}
+                  placeholder={placeholder}
+                  onChange={(e) => setCreateDraft({ value: e.target.value })}
+                  onKeyDown={(e) => e.key === "Enter" && submit()}
+                />
+              )}
               <Button
                 type="button"
                 onClick={submit}
@@ -286,6 +301,7 @@ export function GrantTypesPanel({ clientId }: PanelProps) {
       field="grantType"
       header="Grant type"
       placeholder="authorization_code"
+      options={GRANT_TYPES}
       load={async () => {
         const r = await getApiV1ClientsByClientIdGranttypes({ path: { clientId } });
         return r.error ? [] : (r.data ?? []);
@@ -310,6 +326,7 @@ export function IdpRestrictionsPanel({ clientId }: PanelProps) {
       field="provider"
       header="Provider"
       placeholder="Google"
+      options={IDP_PROVIDERS}
       load={async () => {
         const r = await getApiV1ClientsByClientIdIdprestrictions({ path: { clientId } });
         return r.error ? [] : (r.data ?? []);

--- a/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/identity-resources/IdentityResourceSubResources.tsx
+++ b/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/pages/identity-resources/IdentityResourceSubResources.tsx
@@ -1,4 +1,5 @@
 import { InputText } from "primereact/inputtext";
+import { Dropdown } from "primereact/dropdown";
 import { Button } from "primereact/button";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPlus } from "@fortawesome/free-solid-svg-icons";
@@ -16,12 +17,13 @@ import type {
   IdentityResourceClaimDto,
   IdentityResourcePropertyDto,
 } from "../../api/generated/types.gen";
+import { CLAIM_TYPES } from "../../utils/knownValues";
 
 interface PanelProps {
   identityResourceId: number;
 }
 
-export function ClaimsPanel({ identityResourceId }: PanelProps) {
+export function ClaimsPanel({ identityResourceId }: Readonly<PanelProps>) {
   const columns: SubResourceColumn<IdentityResourceClaimDto>[] = [
     { field: "type", header: "Type" },
   ];
@@ -55,12 +57,13 @@ export function ClaimsPanel({ identityResourceId }: PanelProps) {
         };
         return (
           <div className="flex gap-2">
-            <InputText
+            <Dropdown
+              editable
               className="flex-1"
               value={createDraft.value}
+              options={CLAIM_TYPES}
               placeholder="email"
-              onChange={(e) => setCreateDraft({ value: e.target.value })}
-              onKeyDown={(e) => e.key === "Enter" && submit()}
+              onChange={(e) => setCreateDraft({ value: e.value ?? "" })}
             />
             <Button
               type="button"
@@ -76,7 +79,7 @@ export function ClaimsPanel({ identityResourceId }: PanelProps) {
   );
 }
 
-export function PropertiesPanel({ identityResourceId }: PanelProps) {
+export function PropertiesPanel({ identityResourceId }: Readonly<PanelProps>) {
   return (
     <SubResourceList<IdentityResourcePropertyDto, { key: string; value: string }>
       title="Custom properties"

--- a/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/utils/knownValues.ts
+++ b/source/Spydersoft.Identity.Admin.Frontend/admin-ui/src/utils/knownValues.ts
@@ -1,0 +1,47 @@
+// Known-value lists used to back dropdowns for fields that are otherwise free text.
+// These are the standard sets defined by the underlying protocol/libraries, not
+// backed by an API endpoint, so they're kept here as static, editable-dropdown data.
+
+// Matches Duende.IdentityServer.IdentityServerConstants.GrantTypes (the individual
+// grant type strings clients are allowed to be assigned, one row per grant type).
+export const GRANT_TYPES = [
+  "authorization_code",
+  "client_credentials",
+  "hybrid",
+  "implicit",
+  "password",
+  "urn:ietf:params:oauth:grant-type:device_code",
+  "urn:openid:params:grant-type:ciba",
+];
+
+// Duende's built-in "local" IdP restriction value (IdentityServerConstants.LocalIdentityProvider)
+// plus the external providers wired up in Spydersoft.Identity/Program.cs. Kept as an
+// editable list since IdP restrictions store an arbitrary authentication scheme name.
+export const IDP_PROVIDERS = ["local", "Google"];
+
+// Common claim types from Duende.IdentityModel.JwtClaimTypes, the set already used
+// when seeding user claims (see Spydersoft.Identity.DataSeeder/Seeding/Identity.cs).
+// Kept as an editable list since any string is accepted server-side.
+export const CLAIM_TYPES = [
+  "sub",
+  "name",
+  "given_name",
+  "family_name",
+  "middle_name",
+  "nickname",
+  "preferred_username",
+  "profile",
+  "picture",
+  "website",
+  "email",
+  "email_verified",
+  "gender",
+  "birthdate",
+  "zoneinfo",
+  "locale",
+  "phone_number",
+  "phone_number_verified",
+  "address",
+  "updated_at",
+  "role",
+];


### PR DESCRIPTION
## Summary
- Client **Grant Types** and **IDP Restrictions** now use an editable dropdown seeded with known values (Duende's grant type constants; `local`/`Google` for IdP restrictions) instead of a plain text box.
- API Resource and Identity Resource **User Claims** now use an editable dropdown seeded with the standard `JwtClaimTypes` set.
- API Resource **Scopes** now pulls from `GET /api/v1/scopes`, matching the existing pattern used for Client Scopes, so only real scopes can be added (previously free text).
- Client **Claim Types** and Role **Claim Type** were intentionally left as free text — both are genuinely arbitrary key/value data with no bounded set in the data model.

All dropdowns remain editable (you can still type a value not in the list), since none of these fields are hard-enforced enums server-side.

## Test plan
- [x] `yarn build` passes (type-checks clean)
- [x] `dotnet test` passes (pre-commit hook)
- [ ] Manually verify each panel in the running admin UI (Client Grant Types/IDP Restrictions, API Resource Scopes/Claims, Identity Resource Claims)